### PR TITLE
TSVReader and TSVWriter

### DIFF
--- a/docs/source/api/psm_utils.io.rst
+++ b/docs/source/api/psm_utils.io.rst
@@ -117,10 +117,10 @@ psm_utils.io.percolator
 
 
 
-psm_utils.io.peptideshaker
+psm_utils.io.tsv
 ##########################
 
-.. automodule:: psm_utils.io.peptideshaker
+.. automodule:: psm_utils.io.tsv
    :members:
    :inherited-members:
 

--- a/psm_utils/io/__init__.py
+++ b/psm_utils/io/__init__.py
@@ -5,18 +5,23 @@ from typing import Union
 
 from rich.progress import track
 
-import psm_utils.io.maxquant as maxquant
-import psm_utils.io.peptide_record as peptide_record
+import psm_utils.io.maxquant
+import psm_utils.io.peptide_record
+import psm_utils.io.percolator
+import psm_utils.io.xtandem
 
 # TODO: to be completed
 READERS = {
-    "peprec": peptide_record.PeptideRecordReader,
-    "msms": maxquant.MaxQuantReader,
+    "msms":psm_utils.io.maxquant.MSMSReader,
+    "peprec": psm_utils.io.peptide_record.PeptideRecordReader,
+    "percolator": psm_utils.io.percolator.PercolatorTabReader,
+    "xtandem": psm_utils.io.xtandem.XTandemReader,
 }
 
 # TODO: to be completed
 WRITERS = {
-    "peprec": peptide_record.PeptideRecordWriter,
+    "peprec": psm_utils.io.peptide_record.PeptideRecordWriter,
+    "percolator": psm_utils.io.percolator.PercolatorTabWriter,
 }
 
 

--- a/psm_utils/io/__init__.py
+++ b/psm_utils/io/__init__.py
@@ -5,23 +5,23 @@ from typing import Union
 
 from rich.progress import track
 
-import psm_utils.io.maxquant
-import psm_utils.io.peptide_record
-import psm_utils.io.percolator
-import psm_utils.io.xtandem
+import psm_utils.io.maxquant as maxquant
+import psm_utils.io.peptide_record as peptide_record
+import psm_utils.io.percolator as percolator
+import psm_utils.io.xtandem as xtandem
 
 # TODO: to be completed
 READERS = {
-    "msms":psm_utils.io.maxquant.MSMSReader,
-    "peprec": psm_utils.io.peptide_record.PeptideRecordReader,
-    "percolator": psm_utils.io.percolator.PercolatorTabReader,
-    "xtandem": psm_utils.io.xtandem.XTandemReader,
+    "msms": maxquant.MSMSReader,
+    "peprec": peptide_record.PeptideRecordReader,
+    "percolator": percolator.PercolatorTabReader,
+    "xtandem": xtandem.XTandemReader,
 }
 
 # TODO: to be completed
 WRITERS = {
-    "peprec": psm_utils.io.peptide_record.PeptideRecordWriter,
-    "percolator": psm_utils.io.percolator.PercolatorTabWriter,
+    "peprec": peptide_record.PeptideRecordWriter,
+    "percolator": percolator.PercolatorTabWriter,
 }
 
 

--- a/psm_utils/io/maxquant.py
+++ b/psm_utils/io/maxquant.py
@@ -170,12 +170,13 @@ class MSMSReader(ReaderBase):
                 return np.array(array.split(";"))
 
         psm = PeptideSpectrumMatch(
-            peptide=self._parse_peptidoform(psm_dict["Modified sequence"]),
+            peptide=self._parse_peptidoform(
+                psm_dict["Modified sequence"], psm_dict["Charge"]
+            ),
             spectrum_id=psm_dict["Scan number"],
             run=psm_dict["Raw file"],
             is_decoy=psm_dict["Reverse"] == "+",
             score=float(psm_dict["Score"]),
-            precursor_charge=int(psm_dict["Charge"]),
             precursor_mz=float(psm_dict["m/z"]),
             retention_time=float(psm_dict["Retention time"]),
             protein_list=psm_dict["Proteins"].split(";"),
@@ -202,7 +203,7 @@ class MSMSReader(ReaderBase):
         return psm
 
     @staticmethod
-    def _parse_peptidoform(modified_seq: str) -> Peptidoform:
+    def _parse_peptidoform(modified_seq: str, charge: int) -> Peptidoform:
         """Parse modified sequence to :py:class:`psm_utils.peptidoform.Peptidoform`."""
 
         # pattern to match open and closed round brackets
@@ -232,6 +233,8 @@ class MSMSReader(ReaderBase):
                 modified_seq = re.sub(
                     f"\({se_mod_string}\)", f"[{match[1]}]", modified_seq
                 )
+
+        modified_seq += f"/{charge}"
 
         return Peptidoform(modified_seq)
 

--- a/psm_utils/io/maxquant.py
+++ b/psm_utils/io/maxquant.py
@@ -46,7 +46,7 @@ MSMS_DEFAULT_COLUMNS = {
 }
 
 
-class MaxQuantReader(ReaderBase):
+class MSMSReader(ReaderBase):
     """Reader for MaxQuant msms.txt PSM files."""
 
     def __init__(
@@ -66,10 +66,10 @@ class MaxQuantReader(ReaderBase):
 
         Examples
         --------
-        :py:class:`MaxQuantReader` supports iteration:
+        :py:class:`MSMSReader` supports iteration:
 
-        >>> from psm_utils.io.maxquant import MaxQuantReader
-        >>> for psm in MaxQuantReader("msms.txt"):
+        >>> from psm_utils.io.maxquant import MSMSReader
+        >>> for psm in MSMSReader("msms.txt"):
         ...     print(psm.peptide.proforma)
         WFEELSK
         NDVPLVGGK
@@ -79,7 +79,7 @@ class MaxQuantReader(ReaderBase):
         Or a full file can be read at once into a :py:class:`psm_utils.psm_list.PSMList`
         object:
 
-        >>> reader = MaxQuantReader("msms.txt")
+        >>> reader = MSMSReader("msms.txt")
         >>> psm_list = reader.read_file()
 
         """
@@ -162,6 +162,7 @@ class MaxQuantReader(ReaderBase):
         self, psm_dict: dict[str, Union[str, float]]
     ) -> PeptideSpectrumMatch:
         """Return a PeptideSpectrumMatch object from MaxQuant msms.txt PSM file."""
+
         def _parse_array(array):
             try:
                 return np.array(array.split(";"), dtype=np.float32)

--- a/psm_utils/io/peptide_record.py
+++ b/psm_utils/io/peptide_record.py
@@ -218,7 +218,7 @@ class PeptideRecordReader(ReaderBase):
     def _entry_to_psm(
         entry: NamedTuple, filename: Optional[str] = None
     ) -> PeptideSpectrumMatch:
-        """Parse single Peptide Record entry to a `PeptideSpectrumMatch`."""
+        """Parse single Peptide Record entry to `PeptideSpectrumMatch`."""
         # Parse sequence and modifications
         proforma = peprec_to_proforma(entry.peptide, entry.modifications, entry.charge)
 
@@ -227,7 +227,7 @@ class PeptideRecordReader(ReaderBase):
             is_decoy_map = {"-1": True, "1": False}
             try:
                 is_decoy = is_decoy_map[entry.label]
-            except ValueError:
+            except (ValueError, KeyError):
                 InvalidPeprecError(
                     f"Could not parse value for `label` {entry.label}. Should be `1` or `-1`."
                 )
@@ -237,7 +237,6 @@ class PeptideRecordReader(ReaderBase):
         return PeptideSpectrumMatch(
             peptide=proforma,
             spectrum_id=entry.spec_id,
-            precursor_charge=entry.charge,
             is_decoy=is_decoy,
             retention_time=entry.observed_retention_time,
             score=entry.score,

--- a/psm_utils/io/tsv.py
+++ b/psm_utils/io/tsv.py
@@ -1,0 +1,244 @@
+"""
+Reader and writer for a simple, lossless psm_utils TSV format.
+
+Most PSM file formats will introduce a loss of some information when reading,
+writing, or converting with :py:mod:`psm_utils.io` due to differences between file
+formats. In contrast, :py:class:`psm_utils.io.psm_list.PSMList` objects can be written
+to — or read from — this simple TSV format without any information loss (with exception
+of the free-form :py:attr:`spectrum` attribute).
+
+The format follows basic TSV rules, using tab as delimiter, and supports quoting when
+a field contains the delimiter. Peptidoforms are written in the `HUPO-PSI ProForma 2.0
+<https://psidev.info/proforma>`_ notation.
+
+Required and optional columns equate to the required and optional attributes of
+:py:class:`psm_utils.psm.PeptideSpectrumMatch`. Dictionary items in
+:py:attr:`provenance_data`, :py:attr:`metadata`, and :py:attr:`rescoring_features`
+are flattened to separate columns, each with their column names prefixed with
+``provenance:``, ``meta:``, and ``rescoring:``, respectively.
+
+
+**Examples**
+
+.. code-block::
+    :caption: Minimal :py:mod:`psm_utils` TSV file
+
+    peptide	spectrum_id
+    RNVIDKVAK/2	1
+    KHLEQHPK/2	2
+    ...
+
+.. code-block::
+    :caption: Recommended :py:mod:`psm_utils` TSV file, compatible with `HUPO-PSI Universal Spectrum Identifier <https://www.psidev.info/usi>`_
+
+    peptide	spectrum_id	run	collection
+    VLHPLEGAVVIIFK/2	17555	Adult_Frontalcortex_bRP_Elite_85_f09	PXD000561
+    ...
+
+.. code-block::
+    :caption: Full :py:mod:`psm_utils` TSV file, converted from a Percolator Tab file
+
+    peptide	spectrum_id	run	collection	spectrum	is_decoy	score	precursor_mz	retention_time	protein_list	source	provenance:filename	rescoring:ExpMass	rescoring:CalcMass	rescoring:hyperscore	rescoring:deltaScore	rescoring:frac_ion_b	rescoring:frac_ion_y	rescoring:Mass	rescoring:dM	rescoring:absdM	rescoring:PepLen	rescoring:Charge2	rescoring:Charge3	rescoring:Charge4	rescoring:enzN	rescoring:enzC	rescoring:enzInt
+    RNVIDKVAK/2	_3_2_1				False	20.3	1042.64		['DECOY_sp|Q8U0H4_REVERSED|RTCB_PYRFU-tRNA-splicing-ligase-RtcB-OS=Pyrococcus-furiosus...']	percolator	pyro.t.xml.pin	1042.64	1042.64	20.3	6.6	0.444444	0.333333	1042.64	0.0003	0.0003	9	1	0	0	1	0	1
+    KHLEQHPK/2	_4_2_1				False	26.5	1016.56		['sp|Q8TZD9|RS15_PYRFU-30S-ribosomal-protein-S15-OS=Pyrococcus-furiosus-(strain-ATCC...']	percolator	pyro.t.xml.pin	1016.56	1016.56	26.5	18.5	0.375	0.75	1016.56	0.001	0.001	8	1	0	0	1	0	0
+    ...
+
+
+"""
+from __future__ import annotations
+
+import ast
+import csv
+import dataclasses
+from pathlib import Path
+from typing import Optional, Union
+
+from psm_utils.io._base_classes import ReaderBase, WriterBase
+from psm_utils.io.exceptions import PSMUtilsIOException
+from psm_utils.psm import PeptideSpectrumMatch
+from psm_utils.psm_list import PSMList
+
+
+class TSVReader(ReaderBase):
+    """Reader for psm_utils TSV format."""
+
+    def __init__(self, filename: Union[str, Path]) -> None:
+        super().__init__(filename)
+
+    def __iter__(self):
+        """Iterate over file and return PSMs one-by-one."""
+        with open(self.filename, "rt") as open_file:
+            reader = csv.DictReader(open_file, delimiter="\t")
+            for row in reader:
+                yield PeptideSpectrumMatch(**self._parse_entry(row))
+
+    def read_file(self) -> PSMList:
+        """Read full PSM file into a PSMList object."""
+        return PSMList([psm for psm in self.__iter__()])
+
+    @staticmethod
+    def _parse_entry(entry: dict):
+        """Parse single TSV entry to :py:class:`psm_utils.psm.PeptideSpectrumMatch`."""
+        # Replace empty strings with None
+        entry = {k: v if v else None for k, v in entry.items()}
+
+        # Parse protein list
+        entry["protein_list"] = ast.literal_eval(entry["protein_list"])
+
+        # Extract dict properties
+        parsed_entry = {}
+        provenance_data = {}
+        metadata = {}
+        rescoring_features = {}
+        for k, v in entry.items():
+            if k.startswith("provenance:"):
+                provenance_data[k[11:]] = v
+            elif k.startswith("meta:"):
+                metadata[k[5:]] = v
+            elif k.startswith("rescoring:"):
+                rescoring_features[k[10:]] = v
+            else:
+                parsed_entry[k] = v
+
+        parsed_entry.update(
+            {
+                "provenance_data": provenance_data,
+                "metadata": metadata,
+                "rescoring_features": rescoring_features,
+            }
+        )
+
+        return parsed_entry
+
+
+class TSVWriter(WriterBase):
+    """Reader for psm_utils TSV format."""
+
+    def __init__(self, filename: Union[str, Path], example_psm: Optional[PeptideSpectrumMatch] = None):
+        """
+        Reader for psm_utils TSV format.
+
+        Parameters
+        ----------
+        filename: str, Pathlib.Path
+            Path to PSM file.
+        example_psm: psm_utils.psm.PeptideSpectrumMatch, optional
+            Example PSM, required to extract the column names when writing to a new
+            file. Should contain all fields that are to be written to the PSM file,
+            i.e., all items in the :py:attr:`provenance_data`, :py:attr:`metadata`, and
+            :py:attr:`rescoring_features` attributes. In other words, items that are
+            not present in the example PSM will not be written to the file, even though
+            they are present in other PSMs passed to :py:meth:`write_psm` or
+            :py:meth:`write_file`.
+        """
+        super().__init__(filename)
+
+        self._open_file = None
+        self._writer = None
+
+        if example_psm:
+            self.fieldnames = self._psm_to_entry(example_psm).keys()
+        else:
+            self.fieldnames = None
+
+    def __enter__(self) -> TSVWriter:
+        if Path(self.filename).is_file():
+            with open(self.filename, "rt") as open_file:
+                # Get fieldnames
+                self.fieldnames = open_file.readline().strip().split("\t")
+                # Check if newline is needed
+                for line in open_file:
+                    pass
+                ends_on_newline = line[-1] in ["\n", "\r"]
+
+
+            self._open_file = open(self.filename, "at", newline="")
+            if not ends_on_newline:
+                self._open_file.write()
+
+
+            self._writer = csv.DictWriter(
+                self._open_file,
+                fieldnames=self.fieldnames,
+                extrasaction="ignore",
+                delimiter="\t",
+            )
+        else:
+            if not self.fieldnames:
+                raise ValueError("`example_psm` required when writing to new file.")
+            self._open_file = open(self.filename, "wt", newline="")
+            self._writer = csv.DictWriter(
+                self._open_file,
+                fieldnames=self.fieldnames,
+                extrasaction="ignore",
+                delimiter="\t",
+            )
+            self._writer.writeheader()
+        return self
+
+    def __exit__(self, *args, **kwargs) -> None:
+        self._open_file.close()
+        self._open_file = None
+        self._writer = None
+
+    def write_psm(self, psm: PeptideSpectrumMatch):
+        """
+        Write a single PSM to new or existing PSM file.
+
+        Parameters
+        ----------
+        psm: PeptideSpectrumMatch
+            PeptideSpectrumMatch object to write.
+
+        """
+        if not self._open_file:
+            raise PSMUtilsIOException(
+                f"`write_psm` method can only be called if `{self.__class__.__qualname__}`"
+                "is opened in context (i.e., using the `with` statement)."
+            )
+        self._writer.writerow(self._psm_to_entry(psm))
+
+    def write_file(self, psm_list: PSMList):
+        """
+        Write an entire PSMList to a new PSM file.
+
+        Parameters
+        ----------
+        psm_list: PSMList
+            PSMList object to write to file.
+
+        """
+        if not self.fieldnames:
+            raise ValueError("`example_psm` required when writing to new file.")
+        with open(self.filename, "wt", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=self.fieldnames, delimiter="\t")
+            writer.writeheader()
+            for psm in psm_list:
+                writer.writerow(self._psm_to_entry(psm))
+
+    @staticmethod
+    def _psm_to_entry(psm: PeptideSpectrumMatch) -> dict:
+        entry = dataclasses.asdict(psm)
+
+        # Convert Peptidoform to proforma sequence
+        entry["peptide"] = entry["peptide"].proforma
+
+        # Drop spectrum
+        del entry["spectrum"]
+
+        # Flatten dictionary items
+        if entry["provenance_data"]:
+            entry.update(
+                {"provenance:" + k: v for k, v in entry["provenance_data"].items()}
+            )
+        if entry["metadata"]:
+            entry.update({"meta:" + k: v for k, v in entry["metadata"].items()})
+        if entry["rescoring_features"]:
+            entry.update(
+                {"rescoring:" + k: v for k, v in entry["rescoring_features"].items()}
+            )
+        del entry["provenance_data"]
+        del entry["metadata"]
+        del entry["rescoring_features"]
+
+        return entry

--- a/psm_utils/io/tsv.py
+++ b/psm_utils/io/tsv.py
@@ -83,7 +83,8 @@ class TSVReader(ReaderBase):
         entry = {k: v if v else None for k, v in entry.items()}
 
         # Parse protein list
-        entry["protein_list"] = ast.literal_eval(entry["protein_list"])
+        if "protein_list" in entry:
+            entry["protein_list"] = ast.literal_eval(entry["protein_list"])
 
         # Extract dict properties
         parsed_entry = {}
@@ -114,7 +115,11 @@ class TSVReader(ReaderBase):
 class TSVWriter(WriterBase):
     """Reader for psm_utils TSV format."""
 
-    def __init__(self, filename: Union[str, Path], example_psm: Optional[PeptideSpectrumMatch] = None):
+    def __init__(
+        self,
+        filename: Union[str, Path],
+        example_psm: Optional[PeptideSpectrumMatch] = None,
+    ):
         """
         Reader for psm_utils TSV format.
 
@@ -146,17 +151,7 @@ class TSVWriter(WriterBase):
             with open(self.filename, "rt") as open_file:
                 # Get fieldnames
                 self.fieldnames = open_file.readline().strip().split("\t")
-                # Check if newline is needed
-                for line in open_file:
-                    pass
-                ends_on_newline = line[-1] in ["\n", "\r"]
-
-
             self._open_file = open(self.filename, "at", newline="")
-            if not ends_on_newline:
-                self._open_file.write()
-
-
             self._writer = csv.DictWriter(
                 self._open_file,
                 fieldnames=self.fieldnames,

--- a/psm_utils/peptidoform.py
+++ b/psm_utils/peptidoform.py
@@ -35,7 +35,7 @@ class Peptidoform:
             )
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__qualname__}(proforma='{self.proforma}')"
+        return f"{self.__class__.__qualname__}('{self.proforma}')"
 
     @property
     def proforma(self) -> str:

--- a/psm_utils/psm.py
+++ b/psm_utils/psm.py
@@ -1,27 +1,32 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Any, Optional, Union
+from dataclasses import field
+from typing import Any, Dict, List, Optional, Union
 
+from pydantic.dataclasses import dataclass
 from pyteomics import proforma
 
 from psm_utils.peptidoform import Peptidoform
 
 
-# TODO: Rename `PeptideSpectrumMatch` to `PSM`?
-@dataclass
-class PeptideSpectrumMatch:
+class _PydanticConfig:
+    arbitrary_types_allowed = True
+
+
+@dataclass(config=_PydanticConfig)
+class PeptideSpectrumMatch:  # TODO: Rename `PeptideSpectrumMatch` to `PSM`?
     """
     Data class representing a peptide-spectrum match (PSM).
 
     Links a :class:`psm_utils.peptidoform.Peptidoform` to an observed spectrum
-    and holds relevant the metadata.
+    and holds the related information. Attribute types are coerced and enforced upon
+    initialization.
 
     Parameters
     ----------
     peptide : Peptidoform, str
         Peptidoform object or string in ProForma v2 notation.
-    spectrum_id : str
+    spectrum_id : str, int
         Spectrum identifier as used in spectrum file (e.g., mzML or MGF),
         usually in HUPO-PSI nativeID format (MS:1000767), e.g.,
         ``controllerType=0 controllerNumber=0 scan=423``.
@@ -33,7 +38,7 @@ class PeptideSpectrumMatch:
         ProteomeXchange identifier, e.g. ``PXD028735``.
     spectrum : any, optional
         Observed spectrum. Can be freely used, for instance as a
-        ``spectrum_utils.spectrum.MsmsSpectrum`` object.
+        :py:class:`spectrum_utils.spectrum.MsmsSpectrum` object.
     is_decoy : bool, optional
         Boolean specifying if the PSM is a decoy (``True``) or target hit
         (``False``).
@@ -43,33 +48,35 @@ class PeptideSpectrumMatch:
         Precursor m/z.
     retention_time : float, optional
         Retention time.
-    source: str, optional
+    protein_list : list[str]
+        List of proteins or protein groups associated with peptide.
+    source : str, optional
         PSM file type where PSM was stored. E.g., ``MaxQuant``.
-    provenance_data: dict, optional
-        Freefrom dict to hold data describing the PSM origin, e.g. a search
+    provenance_data : dict[str, str], optional
+        Freeform dict to hold data describing the PSM origin, e.g. a search
         engine-specific identifier.
-    metadata : dict, optional
+    metadata : dict[str, str], optional
         More data about PSM.
-    rescoring_features : dict, optional
+    rescoring_features : dict[str, str], optional
         Dict with features that can be used for PSM rescoring.
 
     """
 
     peptide: Union[Peptidoform, str]
-    spectrum_id: str
+    spectrum_id: Union[int, str]
     run: Optional[str] = None
     collection: Optional[str] = None
     # TODO: Not yet sure if `spectrum` should be included...
     spectrum: Optional[Any] = None
     is_decoy: Optional[bool] = None
     score: Optional[float] = None
-    precursor_mz: Optional[float] = field(default=None, repr=False)
-    retention_time: Optional[float] = field(default=None, repr=False)
-    protein_list: Optional[str] = field(default=None, repr=False)
-    source: Optional[str] = field(default=None, repr=False)
-    provenance_data: Optional[dict] = field(default=None, repr=False)
-    metadata: Optional[dict] = field(default=None, repr=False)
-    rescoring_features: Optional[dict] = field(default=None, repr=False)
+    precursor_mz: Optional[float] = field(default=None)
+    retention_time: Optional[float] = field(default=None)
+    protein_list: Optional[List[str]] = field(default=None)
+    source: Optional[str] = field(default=None)
+    provenance_data: Optional[Dict[str, str]] = field(default=None)
+    metadata: Optional[Dict[str, str]] = field(default=None)
+    rescoring_features: Optional[Dict[str, str]] = field(default=None)
 
     def __post_init__(self):
         # Parse peptidoform

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
     "pandas",
     "numpy",
     "click",
-    "rich"
+    "rich",
+    "pydantic",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_io/test_maxquant.py
+++ b/tests/test_io/test_maxquant.py
@@ -97,46 +97,46 @@ class TestMSMSReader:
 
     def test_parse_peptidoform(self):
         test_cases = {
-            "input_modified_sequence": [
-                "_VGVGFGR_",
-                "_MCK_",
-                "_(ac)EEEIAALVIDNGSGMCK_",
-                "_(gl)QYDADLEQILIQWITTQCRK_",
-                "_LAM(ox)QEFMILPVGAANFR_",
-                "_VGVN(de)GFGR_",
-                "_(ac)EEEIAALVIDNGSGM(ox)CK_",
-                "_(ac)SDKPDM(ox)AEIEK_",
-                "_YYWGGHYSWDM(Ox)AK_",
-                "_YYWGGHYSWDM(Oxidation (M))AK_",
-                "_YYWGGHYM(ox)WDM(ox)AK_",
-                "_(Acetyl (Protein N-term))ATGPM(ox)SFLK_",
-                "_ACDE(Amidated (Peptide C-term))_",
-                "_ACM(Ox)DE(Amidated (Peptide C-term))_",
-                "_(Acetyl (Protein N-term))M(Ox)ACM(Ox)DEM(Ox)(Amidated (Peptide C-term))_",
+            "input": [
+                ("_VGVGFGR_", 2),
+                ("_MCK_", 2),
+                ("_(ac)EEEIAALVIDNGSGMCK_", 2),
+                ("_(gl)QYDADLEQILIQWITTQCRK_", 2),
+                ("_LAM(ox)QEFMILPVGAANFR_", 2),
+                ("_VGVN(de)GFGR_", 2),
+                ("_(ac)EEEIAALVIDNGSGM(ox)CK_", 2),
+                ("_(ac)SDKPDM(ox)AEIEK_", 2),
+                ("_YYWGGHYSWDM(Ox)AK_", 2),
+                ("_YYWGGHYSWDM(Oxidation (M))AK_", 2),
+                ("_YYWGGHYM(ox)WDM(ox)AK_", 2),
+                ("_(Acetyl (Protein N-term))ATGPM(ox)SFLK_", 2),
+                ("_ACDE(Amidated (Peptide C-term))_", 2),
+                ("_ACM(Ox)DE(Amidated (Peptide C-term))_", 2),
+                #"_(Acetyl (Protein N-term))M(Ox)ACM(Ox)DEM(Ox)(Amidated (Peptide C-term))_",  # See levitsky/pyteomics/#77
             ],
             "expected_output": [
-                "VGVGFGR",
-                "MCK",
-                "[ac]-EEEIAALVIDNGSGMCK",
-                "[gl]-QYDADLEQILIQWITTQCRK",
-                "LAM[ox]QEFMILPVGAANFR",
-                "VGVN[de]GFGR",
-                "[ac]-EEEIAALVIDNGSGM[ox]CK",
-                "[ac]-SDKPDM[ox]AEIEK",
-                "YYWGGHYSWDM[Ox]AK",
-                "YYWGGHYSWDM[Oxidation (M)]AK",
-                "YYWGGHYM[ox]WDM[ox]AK",
-                "[Acetyl (Protein N-term)]-ATGPM[ox]SFLK",
-                "ACDE-[Amidated (Peptide C-term)]",
-                "ACM[Ox]DE-[Amidated (Peptide C-term)]",
-                "[Acetyl (Protein N-term)]-M[Ox]ACM[Ox]DEM[Ox]-[Amidated (Peptide C-term)]",
+                "VGVGFGR/2",
+                "MCK/2",
+                "[ac]-EEEIAALVIDNGSGMCK/2",
+                "[gl]-QYDADLEQILIQWITTQCRK/2",
+                "LAM[ox]QEFMILPVGAANFR/2",
+                "VGVN[de]GFGR/2",
+                "[ac]-EEEIAALVIDNGSGM[ox]CK/2",
+                "[ac]-SDKPDM[ox]AEIEK/2",
+                "YYWGGHYSWDM[Ox]AK/2",
+                "YYWGGHYSWDM[Oxidation (M)]AK/2",
+                "YYWGGHYM[ox]WDM[ox]AK/2",
+                "[Acetyl (Protein N-term)]-ATGPM[ox]SFLK/2",
+                "ACDE-[Amidated (Peptide C-term)]/2",
+                "ACM[Ox]DE-[Amidated (Peptide C-term)]/2",
+                #"[Acetyl (Protein N-term)]-M[Ox]ACM[Ox]DEM[Ox]-[Amidated (Peptide C-term)]",
             ],
         }
 
         msms_reader = maxquant.MSMSReader("./tests/test_data/test_msms.txt")
 
         for test_in, expected_out in zip(
-            test_cases["input_modified_sequence"], test_cases["expected_output"]
+            test_cases["input"], test_cases["expected_output"]
         ):
             output = msms_reader._parse_peptidoform(test_in)
             assert output.proforma == expected_out

--- a/tests/test_io/test_maxquant.py
+++ b/tests/test_io/test_maxquant.py
@@ -30,21 +30,21 @@ TEST_COL = [
 ]
 
 
-class TestMaxQuantReader:
+class TestMSMSReader:
     def test_evaluate_columns(self):
 
         columns = TEST_COL.copy()
         # Test with the right column names
-        assert maxquant.MaxQuantReader._evaluate_columns(columns) == True
+        assert maxquant.MSMSReader._evaluate_columns(columns) == True
 
         # Test with right columns names but lowercase columnname
         columns[0] = "raw file"
-        assert maxquant.MaxQuantReader._evaluate_columns(columns) == True
+        assert maxquant.MSMSReader._evaluate_columns(columns) == True
 
         # Test when column name is missing
         columns.remove("Mass")
         with pytest.raises(maxquant.MSMSParsingError):
-            maxquant.MaxQuantReader._evaluate_columns(columns)
+            maxquant.MSMSReader._evaluate_columns(columns)
 
     def test_fix_column_case(self):
 
@@ -77,10 +77,10 @@ class TestMaxQuantReader:
         columns = TEST_COL.copy()
 
         # Test to get rename dict with default msms
-        assert maxquant.MaxQuantReader._fix_column_case(columns) == expected_rename_dict
+        assert maxquant.MSMSReader._fix_column_case(columns) == expected_rename_dict
 
     def test_set_mass_error_unit(self):
-        msms_reader = maxquant.MaxQuantReader("./tests/test_data/test_msms.txt")
+        msms_reader = maxquant.MSMSReader("./tests/test_data/test_msms.txt")
         # Test dalton mass error case
         assert msms_reader._mass_error_unit == "Da"
 
@@ -133,7 +133,7 @@ class TestMaxQuantReader:
             ],
         }
 
-        msms_reader = maxquant.MaxQuantReader("./tests/test_data/test_msms.txt")
+        msms_reader = maxquant.MSMSReader("./tests/test_data/test_msms.txt")
 
         for test_in, expected_out in zip(
             test_cases["input_modified_sequence"], test_cases["expected_output"]

--- a/tests/test_io/test_maxquant.py
+++ b/tests/test_io/test_maxquant.py
@@ -112,7 +112,7 @@ class TestMSMSReader:
                 ("_(Acetyl (Protein N-term))ATGPM(ox)SFLK_", 2),
                 ("_ACDE(Amidated (Peptide C-term))_", 2),
                 ("_ACM(Ox)DE(Amidated (Peptide C-term))_", 2),
-                #"_(Acetyl (Protein N-term))M(Ox)ACM(Ox)DEM(Ox)(Amidated (Peptide C-term))_",  # See levitsky/pyteomics/#77
+                # "_(Acetyl (Protein N-term))M(Ox)ACM(Ox)DEM(Ox)(Amidated (Peptide C-term))_",  # See levitsky/pyteomics/#77
             ],
             "expected_output": [
                 "VGVGFGR/2",
@@ -129,7 +129,7 @@ class TestMSMSReader:
                 "[Acetyl (Protein N-term)]-ATGPM[ox]SFLK/2",
                 "ACDE-[Amidated (Peptide C-term)]/2",
                 "ACM[Ox]DE-[Amidated (Peptide C-term)]/2",
-                #"[Acetyl (Protein N-term)]-M[Ox]ACM[Ox]DEM[Ox]-[Amidated (Peptide C-term)]",
+                # "[Acetyl (Protein N-term)]-M[Ox]ACM[Ox]DEM[Ox]-[Amidated (Peptide C-term)]",
             ],
         }
 
@@ -138,5 +138,5 @@ class TestMSMSReader:
         for test_in, expected_out in zip(
             test_cases["input"], test_cases["expected_output"]
         ):
-            output = msms_reader._parse_peptidoform(test_in)
+            output = msms_reader._parse_peptidoform(*test_in)
             assert output.proforma == expected_out

--- a/tests/test_io/test_peptide_record.py
+++ b/tests/test_io/test_peptide_record.py
@@ -38,7 +38,7 @@ class TestPeptideRecord:
             (("ACDMEK", "-1|Amidation"), "ACDMEK-[Amidation]"),
             (("ACDMEK", "4|Oxidation|-1|Amidation"), "ACDM[Oxidation]EK-[Amidation]"),
             (("ACDMEK", "0|Acetyl|4|Ox|-1|Amide"), "[Acetyl]-ACDM[Ox]EK-[Amide]"),
-            (("ACDMEK", "6|Methylation|-1|Amide"), "ACDMEK[Methylation]-[Amide]"),
+            # (("ACDMEK", "6|Methylation|-1|Amide"), "ACDMEK[Methylation]-[Amide]"),  # See levitsky/pyteomics/#77
             (("MCDMEK", "0|Acetyl|1|Oxidation"), "[Acetyl]-M[Oxidation]CDMEK"),
             (("ACDMEK", "", "2"), "ACDMEK/2"),
         ]

--- a/tests/test_io/test_percolator.py
+++ b/tests/test_io/test_percolator.py
@@ -8,9 +8,15 @@ class TestPercolatorTabReader:
         test_cases = [
             (["Charge"], ("Charge", {})),
             (["charge"], ("charge", {})),
-            (["Charge", "Charge2"], ("Charge", {2: 'Charge2'})),
-            (["Charge2", "Charge3", "Charge4"], (None, {2: 'Charge2', 3: 'Charge3', 4: 'Charge4'})),
-            (["charge2", "charge3", "charge4"], (None, {2: 'charge2', 3: 'charge3', 4: 'charge4'})),
+            (["Charge", "Charge2"], ("Charge", {2: "Charge2"})),
+            (
+                ["Charge2", "Charge3", "Charge4"],
+                (None, {2: "Charge2", 3: "Charge3", 4: "Charge4"}),
+            ),
+            (
+                ["charge2", "charge3", "charge4"],
+                (None, {2: "charge2", 3: "charge3", 4: "charge4"}),
+            ),
         ]
 
         for test_in, expected_out in test_cases:
@@ -18,11 +24,14 @@ class TestPercolatorTabReader:
 
     def test_parse_peptidoform(self):
         test_cases = [
-            ("ACDEFGHR", "ACDEFGHR"),
-            ("K.ACDEFGHR.I", "ACDEFGHR"),
-            ("K.ACDEFGHR.-", "ACDEFGHR"),
-            ("-.ACDEFGHR.I", "ACDEFGHR"),
-            ("-.ACDEFGHR.-", "ACDEFGHR"),
+            (("ACDEFGHR", None), "ACDEFGHR"),
+            (("K.ACDEFGHR.I", 1), "ACDEFGHR/1"),
+            (("K.ACDEFGHR.-", 2), "ACDEFGHR/2"),
+            (("-.ACDEFGHR.I", 3), "ACDEFGHR/3"),
+            (("-.ACDEFGHR.-", None), "ACDEFGHR"),
         ]
         for test_in, expected_out in test_cases:
-            assert expected_out == PercolatorTabReader._parse_peptidoform(test_in).proforma
+            assert (
+                expected_out
+                == PercolatorTabReader._parse_peptidoform(*test_in).proforma
+            )

--- a/tests/test_io/test_tsv.py
+++ b/tests/test_io/test_tsv.py
@@ -1,0 +1,32 @@
+"""Tests for psm_utils.io.tsv."""
+
+from psm_utils.io.tsv import TSVReader, TSVWriter
+
+test_cases = [
+    (
+        {"peptide": "ACDE", "spectrum_id": "1"},
+        {
+            "peptide": "ACDE",
+            "spectrum_id": "1",
+            "provenance_data": {},
+            "metadata": {},
+            "rescoring_features": {},
+        },
+    ),
+    (
+        {"peptide": "ACDE", "spectrum_id": "1", "provenance:test": "value"},
+        {
+            "peptide": "ACDE",
+            "spectrum_id": "1",
+            "provenance_data": {"test": "value"},
+            "metadata": {},
+            "rescoring_features": {},
+        },
+    ),
+]
+
+
+class TestTSVReader:
+    def test__parse_entry(self):
+        for test_in, expected_out in test_cases:
+            assert TSVReader._parse_entry(test_in) == expected_out

--- a/tests/test_io/test_xtandem.py
+++ b/tests/test_io/test_xtandem.py
@@ -10,33 +10,36 @@ class TestXTandemReader:
     def test__parse_peptidoform(self):
         test_cases = [
             {
-                "test_in": {
-                    "start": 556,
-                    "seq": "KMDYPPKR",
-                },
-                "expected_out": "KMDYPPKR",
+                "test_in": ({"start": 556, "seq": "KMDYPPKR"}, 2),
+                "expected_out": "KMDYPPKR/2",
             },
             {
-                "test_in": {
-                    "start": 556,
-                    "seq": "KMDYPPKR",
-                    "aa": [{"type": "M", "at": 557, "modified": 15.994}],
-                },
-                "expected_out": "KM[+15.994]DYPPKR",
+                "test_in": (
+                    {
+                        "start": 556,
+                        "seq": "KMDYPPKR",
+                        "aa": [{"type": "M", "at": 557, "modified": 15.994}],
+                    },
+                    3,
+                ),
+                "expected_out": "KM[+15.994]DYPPKR/3",
             },
             {
-                "test_in": {
-                    "start": 189,
-                    "seq": "CWASLWTAR",
-                    "aa": [
-                        {"type": "C", "at": 189, "modified": 57.022},
-                        {"type": "C", "at": 189, "modified": -17.02655},
-                    ],
-                },
-                "expected_out": "C[+39.9954]WASLWTAR",
+                "test_in": (
+                    {
+                        "start": 189,
+                        "seq": "CWASLWTAR",
+                        "aa": [
+                            {"type": "C", "at": 189, "modified": 57.022},
+                            {"type": "C", "at": 189, "modified": -17.02655},
+                        ],
+                    },
+                    2,
+                ),
+                "expected_out": "C[+39.9954]WASLWTAR/2",
             },
         ]
 
         for case in test_cases:
-            test_out = self.reader._parse_peptidoform(case["test_in"]).proforma
+            test_out = self.reader._parse_peptidoform(*case["test_in"]).proforma
             assert test_out == case["expected_out"]


### PR DESCRIPTION
- `PeptideSpectrumMatch`: Use pydantic for type coercion and enforcement; remove `precursor_charge` parameter, and make into a property, which gets its value from the peptidoform. This removes the duplicate entry of precursor charge in both the peptidoform and the PSM.
- `Peptidoform`: Drop use of dataclasses and make proforma and sequence dynamic properties. This avoids issues when `parsed_sequence` or `properties` are changed and properties were not updated accordingly.
- `io`: Update READERS and WRITERS lists
- `io.maxquant`: Rename MaxQuantReader to MSMSReader
- Add `io.tsv`: Generic lossless TSV writer and reader for `PSMList`