### PR TITLE
psm_utils online; various related changes

### DIFF
--- a/online/.streamlit/config.toml
+++ b/online/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[theme]
+base="light"

--- a/online/Home.py
+++ b/online/Home.py
@@ -1,0 +1,13 @@
+"""psm_utils Streamlit-based web server."""
+
+import streamlit as st
+from _base import StreamlitPage
+
+
+class StreamlitPageHome(StreamlitPage):
+    def _main_page(self):
+        pass
+
+
+if __name__ == "__main__":
+    StreamlitPageHome()

--- a/online/README.md
+++ b/online/README.md
@@ -1,0 +1,22 @@
+# psm_utils online
+
+psm_utils online is a Streamlit-based web server, built on top of the psm_utils
+Python package. It allows you to easily get proteomics peptide-spectrum match
+(PSM) statistics for any supported PSM file type, and to convert search engine
+results from one PSM file format into another.
+
+
+## Development setup
+
+Install with pip in editable mode, using the `dev` and `online` optional
+dependencies:
+
+```sh
+pip install --editable .[dev,online]
+```
+
+Start a local Streamlit web server:
+
+```sh
+streamlit run .\online\Home.py
+```

--- a/online/_base.py
+++ b/online/_base.py
@@ -1,0 +1,92 @@
+"""Base classes for psm_utils online Streamlit web server."""
+
+from abc import ABC, abstractmethod
+
+import streamlit as st
+
+
+class StreamlitPage(ABC):
+    """Base class for psm_utils online Streamlit web server."""
+
+    def __init__(self) -> None:
+        self.state = st.session_state
+
+        st.set_page_config(
+            page_title="psm_utils online",
+            page_icon=":rocket:",
+            layout="centered",
+            initial_sidebar_state="expanded",
+        )
+
+        # Instantiate session_state items
+        stateful_items = [
+            "input_file",
+            "output_file",
+            "input_filetype",
+            "output_filetype",
+            "fdr_threshold",
+            "reverse",
+            "file_state",
+            "psm_list",
+            "psm_df",
+            "percolator_score_column",
+            "convert_input_file",
+            "convert_input_filetype",
+            "convert_output_filetype",
+        ]
+        for item in stateful_items:
+            if item not in self.state:
+                self.state[item] = None
+
+        self._preface()
+        self._main_page()
+        self._sidebar()
+
+    def _preface(self):
+        st.markdown(
+            """
+            # psm_utils online
+
+            **psm_utils online** is a [Streamlit](http://streamlit.io/)-based web server,
+            built on top of the [psm_utils](https://psm-utils.readthedocs.io/) Python
+            package. It allows you to easily get **proteomics peptide-spectrum match
+            (PSM) statistics** for any supported PSM file type, and to **convert search
+            engine results** from one PSM file format into another.
+
+            **👈 Select a page from the sidebar to get started!**<br>
+            **📖 Learn more about psm_utils on
+            [readthedocs.io](https://psm-utils.readthedocs.io/)**<br>
+            **💻 Find the source code on
+            [github.com](https://github.com/compomics/psm_utils)**<br>
+            """,
+            unsafe_allow_html=True,
+        )
+
+    @abstractmethod
+    def _main_page(self):
+        raise NotImplementedError()
+
+    def _sidebar(self):
+        """Format sidebar."""
+        st.sidebar.markdown(
+            """
+            # psm_utils online
+
+            [![GitHub release](https://img.shields.io/github/v/release/compomics/psm_utils?include_prereleases&sort=semver&style=flat-square)](https://github.com/compomics/psm_utils/releases)
+            [![GitHub](https://img.shields.io/github/license/compomics/psm_utils?style=flat-square)](https://github.com/compomics/psm_utils/blob/main/LICENSE)
+            [![Twitter Follow](https://img.shields.io/twitter/follow/CompOmics?style=flat-square)](https://twitter.com/compomics)
+
+            psm_utils is a Python package with utilities for parsing and handling
+            peptide-spectrum matches (PSMs) and proteomics search engine results. It is
+            mainly developed to be used in Python packages developed at CompOmics, such
+            as [MS²PIP](https://github.com/compomics/ms2pip_c/),
+            [DeepLC](https://github.com/compomics/deeplc/), and
+            [MS²Rescore](https://github.com/compomics/ms2rescore/),
+            but can be useful to anyone dealing with PSMs and PSM files.
+
+            This web server is built on top of
+            **[psm_utils](https://psm-utils.readthedocs.io/)** and allows you to easily
+            get **PSM statistics** for any supported PSM file type, and to **convert
+            search engine results** from one PSM file format into another.
+            """
+        )

--- a/online/_utils.py
+++ b/online/_utils.py
@@ -1,0 +1,116 @@
+import numpy as np
+import plotly.express as px
+import plotly.graph_objects as go
+
+
+class ECDF:
+    """
+    Return the Empirical CDF of an array as a step function.
+
+    Parameters
+    ----------
+    x : array_like
+        Observations
+    """
+
+    def __init__(self, x):
+        # Get ECDF
+        x = np.array(x, copy=True)
+        x.sort()
+        nobs = len(x)
+        y = np.linspace(1.0 / nobs, 1, nobs)
+
+        # Make into step function
+        _x = np.asarray(x)
+        _y = np.asarray(y)
+
+        if _x.shape != _y.shape:
+            msg = "x and y do not have the same shape"
+            raise ValueError(msg)
+        if len(_x.shape) != 1:
+            msg = "x and y must be 1-dimensional"
+            raise ValueError(msg)
+
+        self.x = np.r_[-np.inf, _x]
+        self.y = np.r_[0.0, _y]
+        self.n = self.x.shape[0]
+
+    def __call__(self, time):
+        tind = np.searchsorted(self.x, time, side="right") - 1
+        return self.y[tind]
+
+
+def score_histogram(psm_df):
+    psm_df = psm_df.copy()
+    psm_df["is_decoy"] = psm_df["is_decoy"].map({True: "decoy", False: "target"})
+    fig = px.histogram(
+        psm_df,
+        x="score",
+        color="is_decoy",
+        barmode="overlay",
+        histnorm="probability density",
+        labels={"is_decoy": "PSM type", "False": "target", "True": "decoy"},
+        opacity=0.75,
+    )
+    return fig
+
+
+def pp_plot(psm_df):
+    """Generate PP plot for given PSM dataframe."""
+    if len(psm_df) > 5000:
+        sample = 5000
+    else:
+        sample = 1.0
+    percent_decoys = np.count_nonzero(psm_df["is_decoy"]) / len(psm_df)
+    if percent_decoys == 0:
+        raise ValueError("No decoy PSMs found in PSM file.")
+    target_scores = psm_df["score"][~psm_df["is_decoy"]]
+    decoy_scores = psm_df["score"][psm_df["is_decoy"]]
+    target_scores_sample = psm_df["score"][~psm_df["is_decoy"]].sample(sample)
+    target_ecdf = ECDF(target_scores)(target_scores_sample)
+    decoy_ecdf = ECDF(decoy_scores)(target_scores_sample)
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter(
+            x=decoy_ecdf,
+            y=target_ecdf,
+            mode="markers",
+        )
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=[0, 1],
+            y=[0, decoy_ratio],
+            mode="lines",
+            line=go.scatter.Line(color="red"),
+            showlegend=True,
+            name="pi0",
+        )
+    )
+    fig.update_layout(
+        xaxis_title="Fdp",
+        yaxis_title="Ftp",
+        showlegend=False,
+    )
+    return fig
+
+
+def fdr_plot(psm_df, fdr_threshold):
+    """Plot number of identifications in function of FDR threshold."""
+    df = (
+        psm_df[~psm_df["is_decoy"]]
+        .reset_index(drop=True)
+        .sort_values("qvalue", ascending=True)
+        .copy()
+    )
+    df["count"] = (~df["is_decoy"]).cumsum()
+    fig = px.line(
+        df,
+        x="qvalue",
+        y="count",
+        log_x=True,
+        labels={"count": "Number of identified target PSMs", "qvalue": "FDR threshold"},
+    )
+    fig.add_vline(x=fdr_threshold, line=go.layout.shape.Line(color="red"))
+    return fig

--- a/online/_utils.py
+++ b/online/_utils.py
@@ -61,8 +61,8 @@ def pp_plot(psm_df):
         sample = 5000
     else:
         sample = 1.0
-    percent_decoys = np.count_nonzero(psm_df["is_decoy"]) / len(psm_df)
-    if percent_decoys == 0:
+    decoy_ratio = np.count_nonzero(psm_df["is_decoy"]) / len(psm_df)
+    if decoy_ratio == 0:
         raise ValueError("No decoy PSMs found in PSM file.")
     target_scores = psm_df["score"][~psm_df["is_decoy"]]
     decoy_scores = psm_df["score"][psm_df["is_decoy"]]

--- a/online/pages/1_PSM_file_statistics.py
+++ b/online/pages/1_PSM_file_statistics.py
@@ -1,0 +1,306 @@
+"""psm_utils Streamlit-based web server."""
+
+from tempfile import NamedTemporaryFile
+
+import numpy as np
+import streamlit as st
+from _base import StreamlitPage
+from _utils import fdr_plot, pp_plot, score_histogram
+
+from psm_utils.io import READERS, _infer_filetype, read_file
+
+
+class StreamlitPageStats(StreamlitPage):
+    """Statistics page for psm_utils online Streamlit web server."""
+
+    def _main_page(self):
+        st.markdown(
+            """
+            ## PSM file statistics
+            """
+        )
+
+        if self._input_form():
+            try:
+                self._read_file()
+                self._prepare_psms()
+            except Exception as e:
+                st.error("Error occurred while reading PSM file.")
+                st.exception(e)
+            else:
+                self._show_results()
+
+    def _input_form(self):
+        with st.form(key="main_form"):
+            self.state["input_file"] = st.file_uploader(
+                label="Input PSM file",
+            )
+            self.state["input_filetype"] = st.selectbox(
+                label="Input PSM file type",
+                options=["infer"] + list(READERS.keys()),
+                index=0,
+            )
+            self.state["use_example_file"] = st.checkbox(
+                label="Use example PSM file",
+            )
+
+            with st.expander("Advanced options"):
+                row = st.columns(3)
+                self.state["decoy_pattern"] = row[0].text_input(
+                    "Decoy pattern",
+                    help=(
+                        """
+                        Decoy protein entries are commonly marked with a prefix or
+                        suffix, e.g. `DECOY_`, or `_REVERSED`. If the target/decoy state
+                        of a PSM is not explicitly encoded in the PSM file, this setting
+                        can be used to find decoy PSMs by trying to match a regular
+                        expression pattern to the protein names. Some patterns that
+                        might work are `^DECOY_` or `_REVERSED$`.
+                        """
+                    ),
+                )
+                self.state["fdr_threshold"] = row[1].number_input(
+                    label="FDR threshold",
+                    min_value=0.0,
+                    max_value=1.0,
+                    step=0.001,
+                    value=0.01,
+                    format="%f",
+                )
+                self.state["reverse"] = row[2].radio(
+                    "Score type",
+                    options=[True, False],
+                    format_func=lambda x: "Higher score is better"
+                    if x == True
+                    else "Lower score is better",
+                )
+                row = st.columns(3)
+                self.state["percolator_score_column"] = row[0].text_input(
+                    "Percolator Tab: Score column",
+                    help=(
+                        """
+                        In Percolator Tab PIN files, the name of the score column is not
+                        predefined. Provide the correct column name to extract PSM
+                        scores from a PIN file.
+                        """
+                    ),
+                )
+
+            submitted = st.form_submit_button("Upload")
+
+        if submitted:
+            if not (self.state["input_file"] or self.state["use_example_file"]):
+                st.error(
+                    "Input PSM file required. Upload a file or select 'Use example PSM file'."
+                )
+            else:
+                return True
+
+    def _read_file(self):
+        with st.spinner("Reading PSM file..."):
+            # Reading file
+            if self.state["use_example_file"]:
+                psm_list = read_file("online\example_data\msms.txt", filetype="msms")
+            else:
+                # Infer filetype if required
+                if st.session_state["input_filetype"] == "infer":
+                    st.session_state["input_filetype"] = _infer_filetype(
+                        st.session_state["input_file"].name
+                    )
+                # Write file to disk for psm_utils; then read
+                with NamedTemporaryFile(mode="wb", delete=False) as tmp_file:
+                    tmp_file.write(self.state["input_file"].getvalue())
+                    tmp_file.flush()
+                    tmp_file.close()
+                    psm_list = read_file(
+                        filename=tmp_file.name,
+                        filetype=self.state["input_filetype"],
+                        score_column=self.state["percolator_score_column"],
+                    )
+        if self.state["decoy_pattern"]:
+            psm_list.find_decoys(self.state["decoy_pattern"])
+
+        self.state["psm_list"] = psm_list
+
+    def _prepare_psms(self):
+        """Calculate q-values if needed; generate psm_df."""
+        psm_list = self.state["psm_list"]
+
+        # Warn if some but only few decoys are present
+        percent_decoys = np.count_nonzero(psm_list["is_decoy"]) / len(psm_list)
+        if 0 < percent_decoys < 0.1:
+            st.warning(
+                f"""
+                An unusually low percentage of decoy PSMs was found
+                ({percent_decoys:.2%}). Are you sure that the PSM file was not already
+                FDR-filtered?
+                """
+            )
+
+        # If no q-values, try to calculate
+        if (psm_list["qvalue"] == None).any():
+            # If no decoys, display error
+            if percent_decoys == 0.0:
+                st.error(
+                    """
+                    No decoys were found in the PSM file and not all PSMs have q-values
+                    assigned. The FDR could therefore not be calculated. Are you sure
+                    that both target and decoy PSMs were returned by the search engine?
+                    If there should be decoys present in the PSM file, you might want
+                    to set the advanced 'Decoy pattern' option.
+                    """
+                )
+                file_state = ["no_qvalues", "no_decoys"]
+            else:
+                st.warning(
+                    """
+                    Not all PSMs have q-values assigned, so q-values will be calculated
+                    based on target and decoy PSM scores. Please ensure that all decoy
+                    PSMs are present in the PSM file to prevent an incorrect
+                    FDR estimation.
+                    """
+                )
+                try:
+                    psm_list.calculate_qvalues(self.state["reverse"])
+                except Exception as e:
+                    st.exception(e)
+                    file_state = ["no_qvalues", "decoys"]
+                else:
+                    file_state = ["qvalues", "decoys"]
+        else:
+            if percent_decoys == 0.0:
+                file_state = ["qvalues", "no_decoys"]
+            else:
+                file_state = ["qvalues", "decoys"]
+
+        self.state["file_state"] = file_state
+        self.state["psm_df"] = psm_list.to_dataframe()
+
+    def _show_results(self):
+        # General stats
+        st.markdown(
+            """
+            ## Results
+            ### Overall statistics
+            Total number of items in the PSM file.
+            """
+        )
+        psm_list = self.state["psm_list"]
+        psm_df = self.state["psm_df"]
+
+        n_collections = psm_df["collection"].unique().shape[0]
+        n_runs = psm_df[["run", "collection"]].drop_duplicates().shape[0]
+        n_spectra = (
+            psm_df[["spectrum_id", "run", "collection"]].drop_duplicates().shape[0]
+        )
+        n_psms = psm_df.shape[0]
+        n_peptidoforms = psm_df["peptide"].apply(lambda x: x.proforma).unique().shape[0]
+        percent_decoys = np.count_nonzero(psm_list["is_decoy"]) / len(psm_list)
+
+        row_1 = st.columns(3)
+        row_1[0].metric(label="Collections", value=n_collections)
+        row_1[1].metric(label="Runs", value=n_runs)
+        row_1[2].metric(label="Spectra", value=n_spectra)
+        row_2 = st.columns(3)
+        row_2[0].metric(label="PSMs", value=n_psms)
+        row_2[1].metric(label="Peptidoforms", value=n_peptidoforms)
+        row_2[2].metric(label="Decoy PSMs", value=f"{percent_decoys:.2%}")
+
+        # FDR-filtered stats
+        st.markdown(
+            """
+            ### FDR-filtered statistics
+            Number of identifications filtered at the FDR threshold as selected in
+            the input form.
+            """
+        )
+        if "no_qvalues" in self.state["file_state"]:
+            st.error("PSM q-values are required to filter on FDR.")
+        else:
+            psm_df_filtered = psm_df[psm_df["qvalue"] <= self.state["fdr_threshold"]]
+            n_spectra = (
+                psm_df_filtered[["spectrum_id", "run", "collection"]]
+                .drop_duplicates()
+                .shape[0]
+            )
+            n_psms = psm_df_filtered.shape[0]
+            n_peptides = psm_df["peptide"].apply(lambda x: x.sequence).unique().shape[0]
+            n_peptidoforms = (
+                psm_df_filtered["peptide"].apply(lambda x: x.proforma).unique().shape[0]
+            )
+
+            row_3 = st.columns(4)
+            row_3[0].metric(label="Spectra", value=n_spectra)
+            row_3[1].metric(label="PSMs", value=n_psms)
+            row_3[2].metric(label="Peptides", value=n_peptides)
+            row_3[3].metric(label="Peptidoforms", value=n_peptidoforms)
+
+        # Plots
+        st.markdown(
+            """
+            ### Target-decoy diagnostic plots
+            #### Score histogram
+            The score histogram shows the score distribution for both target and
+            decoy PSMs.
+            """
+        )
+        try:
+            st.plotly_chart(score_histogram(psm_df), use_container_width=True)
+        except Exception as e:
+            st.error(e)
+
+        st.markdown(
+            """
+            #### Percentile-percentile plot
+            The percentile-percentile (PP) plot shows the empirical cumulative
+            distribution function (ECDF) of the target distribution in function of
+            the ECDF of the decoy distribution. In the context of peptide
+            identification, it can be used to assess the quality of decoy PSMs and
+            their capacity to help in correctly estimating the false discovery rate.
+
+            Ideally, the PP-plot should follow a straight diagonal line up until the
+            end of the decoy distribution (right-hand side of the plot), where the
+            line turns vertically upwards. This means that the decoy distribution
+            perfectly aligns with the first part of the target distribution (the
+            low-scoring and presumably bad target PSMs) and therefore correctly
+            models the bad target PSMs. This diagonal line matches the ratio of
+            the number of decoy to the number of target PSMs ($\widehat{\pi}_0$).
+
+            More information on this type of diagnostic plot can be found at
+            [statomics.github.io/TargetDecoy](https://statomics.github.io/TargetDecoy/articles/TargetDecoy.html).
+
+            """
+        )
+        if "no_decoys" in self.state["file_state"]:
+            st.error("Decoy PSMs are required to generate this plot.")
+        else:
+            try:
+                st.plotly_chart(pp_plot(psm_df), use_container_width=True)
+            except Exception as e:
+                st.exception(e)
+
+        st.markdown(
+            """
+            #### False discovery rate plot
+            This plot shows the number of identified target PSMs in function of the
+            FDR threshold. The plot starts at the top-right corner with
+            the total number of PSMs in the dataset (no FDR filtering). As the FDR
+            threshold becomes more stringent (towards the left of the x-axis), the
+            number of identified target PSMs goes down. The red vertical line
+            indicates the FDR threshold as selected in the input form.
+            """
+        )
+        if "no_qvalues" in self.state["file_state"]:
+            st.error("PSM q-values are required to generate this plot.")
+        else:
+            try:
+                st.plotly_chart(
+                    fdr_plot(psm_df, self.state["fdr_threshold"]),
+                    use_container_width=True,
+                )
+            except Exception as e:
+                st.exception(e)
+
+
+if __name__ == "__main__":
+    StreamlitPageStats()

--- a/online/pages/2_PSM_file_conversion.py
+++ b/online/pages/2_PSM_file_conversion.py
@@ -1,0 +1,87 @@
+"""psm_utils Streamlit-based web server."""
+
+import os
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+import streamlit as st
+from _base import StreamlitPage
+
+from psm_utils.io import FILETYPES, READERS, WRITERS, _infer_filetype, convert
+
+
+class StreamlitPageConvert(StreamlitPage):
+    """Conversion page for psm_utils online Streamlit web server."""
+
+    def _main_page(self):
+        st.markdown(
+            """
+            ## PSM file conversion
+            """
+        )
+        with st.form(key="main_form"):
+            st.session_state["convert_input_file"] = st.file_uploader(
+                label="Input PSM file",
+            )
+            st.session_state["convert_input_filetype"] = st.selectbox(
+                label="Input PSM file type",
+                options=["infer"] + list(READERS.keys()),
+                index=0,
+            )
+            st.session_state["convert_output_filetype"] = st.selectbox(
+                label="Output PSM file type",
+                options=WRITERS.keys(),
+                index=2,
+            )
+
+            submitted = st.form_submit_button("Convert")
+
+        if submitted:
+            if not self.state["convert_input_file"]:
+                st.error("Input PSM file required.")
+            else:
+                self._convert()
+
+    def _convert(self):
+        with st.spinner("Converting PSM file..."):
+            # Infer filetype if required
+            if st.session_state["convert_input_filetype"] == "infer":
+                st.session_state["convert_input_filetype"] = _infer_filetype(
+                    st.session_state["convert_input_file"].name
+                )
+
+            try:
+                # Write uploaded file to disk and convert
+                with NamedTemporaryFile(mode="wb", delete=False) as tmp_file:
+                    tmp_file.write(st.session_state["convert_input_file"].getvalue())
+                    tmp_file.flush()
+                    tmp_file.close()
+                    convert(
+                        input_filename=tmp_file.name,
+                        output_filename="output_filename",
+                        input_filetype=st.session_state["convert_input_filetype"],
+                        output_filetype=st.session_state["convert_output_filetype"],
+                    )
+            except Exception as e:
+                st.exception(e)
+            else:
+                st.success("PSM file successfully converted!")
+
+                # Construct output filename with new extension
+                output_filename = Path(
+                    st.session_state["convert_input_file"].name
+                ).stem + FILETYPES[st.session_state["convert_output_filetype"]]["extension"]
+
+                # Open converted file in memory for download button
+                with open("output_filename", "rb") as file:
+                    is_downloaded = st.download_button(
+                        "Download",
+                        data=file,
+                        file_name=output_filename,
+                        mime="text/plain",
+                    )
+                os.remove("output_filename")
+
+
+if __name__ == "__main__":
+    StreamlitPageConvert()

--- a/psm_utils/io/__init__.py
+++ b/psm_utils/io/__init__.py
@@ -1,5 +1,6 @@
 """Parsers for proteomics search results from various search engines."""
 
+import re
 from pathlib import Path
 from typing import Union
 
@@ -11,28 +12,61 @@ import psm_utils.io.peptide_record as peptide_record
 import psm_utils.io.percolator as percolator
 import psm_utils.io.tsv as tsv
 import psm_utils.io.xtandem as xtandem
+from psm_utils.io.exceptions import PSMUtilsIOException
 
 # TODO: to be completed
-READERS = {
-    "idxml": idxml.IdXMLReader,
-    "msms": maxquant.MSMSReader,
-    "peprec": peptide_record.PeptideRecordReader,
-    "percolator": percolator.PercolatorTabReader,
-    "tsv": tsv.TSVReader,
-    "xtandem": xtandem.XTandemReader,
-}
+FILETYPES = {
+    "idxml": {
+        "reader": idxml.IdXMLReader,
+        "writer": None,
+        "extension": ".idXML",
+        "filename_pattern": r"^.*\.idxml$",
+    },
+    "msms": {
+        "reader": maxquant.MSMSReader,
+        "writer": None,
+        "extension": "_msms.txt",
+        "filename_pattern": r"^msms\.txt$",
+    },
 
-# TODO: to be completed
-WRITERS = {
-    "peprec": peptide_record.PeptideRecordWriter,
-    "percolator": percolator.PercolatorTabWriter,
-    "tsv": tsv.TSVWriter,
-}
+    "peprec": {
+        "reader": peptide_record.PeptideRecordReader,
+        "writer": peptide_record.PeptideRecordWriter,
+        "extension": ".peprec.txt",
+        "filename_pattern": r"(^.*\.peprec(?:\.txt)?$)|(^peprec\.txt$)",
+    },
 
+    "percolator": {
+        "reader": percolator.PercolatorTabReader,
+        "writer": percolator.PercolatorTabWriter,
+        "extension": ".percolator.txt",
+        "filename_pattern": r"^.*\.(?:(?:pin)|(?:pout))$",
+    },
+
+    "tsv": {
+        "reader": tsv.TSVReader,
+        "writer": tsv.TSVWriter,
+        "extension": ".tsv",
+        "filename_pattern": r"^.*\.tsv$",
+    },
+
+    "xtandem": {
+        "reader": xtandem.XTandemReader,
+        "writer": None,
+        "extension": ".t.xml",
+        "filename_pattern": r"^.*\.t\.xml$",
+    },
+}
+READERS = {k: v["reader"] for k, v in FILETYPES.items() if v["reader"]}
+WRITERS = {k: v["writer"] for k, v in FILETYPES.items() if v["writer"]}
 
 def _infer_filetype(filename: str):
-    """Infer filetype from file extension."""
-    raise NotImplementedError()
+    """Infer filetype from filename."""
+    for filetype, properties in FILETYPES.items():
+        if re.fullmatch(properties["filename_pattern"], filename, flags=re.IGNORECASE):
+            return filetype
+    else:
+        raise PSMUtilsIOException("Could not infer filetype.")
 
 
 def read_file(filename: Union[str, Path], *args, filetype: str = "infer", **kwargs):
@@ -44,7 +78,8 @@ def read_file(filename: Union[str, Path], *args, filetype: str = "infer", **kwar
     filename: str
         Path to file.
     filetype: str, optional
-        File type. Any of {#TODO: add list}.
+        File type. Any PSM file type with read support. See
+        :ref:`Supported file formats`.
     *args : tuple
         Additional arguments are passed to the :py:class:`psm_utils.io` reader.
     **kwargs : dict, optional
@@ -57,6 +92,11 @@ def read_file(filename: Union[str, Path], *args, filetype: str = "infer", **kwar
     reader = reader_cls(filename, *args, **kwargs)
     psm_list = reader.read_file()
     return psm_list
+
+
+def write_file():
+    # TODO
+    raise ImplementedError()
 
 
 def convert(
@@ -76,9 +116,11 @@ def convert(
     output_filename: str
         Path to output file.
     input_filetype: str, optional
-        Input file type. Any of {#TODO: add list}.
+        File type. Any PSM file type with read support. See
+        :ref:`Supported file formats`.
     output_filetype: str, optional
-        Output file type. Any of {#TODO: add list}.
+        File type. Any PSM file type with write support. See
+        :ref:`Supported file formats`.
     show_progressbar: bool, optional
         Show progress bar for conversion process. (default: False)
 
@@ -116,10 +158,18 @@ def convert(
     reader_cls = READERS[input_filetype]
     writer_cls = WRITERS[output_filetype]
 
-    reader = reader_cls(input_filename)
-    writer = writer_cls(output_filename)
+    # Remove file if already exists to avoid appending:
+    if Path(output_filename).is_file():
+        Path(output_filename).unlink()
 
+    reader = reader_cls(input_filename)
     iterator = track(reader) if show_progressbar else reader
 
-    for psm in iterator:
-        writer.write(psm)
+    for psm in reader:
+        example_psm = psm
+        break
+    writer = writer_cls(output_filename, example_psm=example_psm, mode="write")
+
+    with writer:
+        for psm in iterator:
+            writer.write_psm(psm)

--- a/psm_utils/io/__init__.py
+++ b/psm_utils/io/__init__.py
@@ -96,7 +96,7 @@ def read_file(filename: Union[str, Path], *args, filetype: str = "infer", **kwar
 
 def write_file():
     # TODO
-    raise ImplementedError()
+    raise NotImplementedError()
 
 
 def convert(

--- a/psm_utils/io/_base_classes.py
+++ b/psm_utils/io/_base_classes.py
@@ -16,6 +16,8 @@ class ReaderBase(ABC):
     def __init__(
         self,
         filename: Union[str, Path],
+        *args,
+        **kwargs,
     ) -> None:
         """
         Reader for PSM file.
@@ -43,7 +45,7 @@ class ReaderBase(ABC):
 class WriterBase(ABC):
     """Abstract base class for PSM file writers."""
 
-    def __init__(self, filename):
+    def __init__(self, filename, *args, **kwargs):
         super().__init__()
         self.filename = Path(filename)
 

--- a/psm_utils/io/idxml.py
+++ b/psm_utils/io/idxml.py
@@ -38,7 +38,7 @@ class IdXMLReader(ReaderBase):
 
     def read_file(self) -> PSMList:
         """Read full PSM file into a PSMList object."""
-        return PSMList([psm for psm in self.__iter__()])
+        return PSMList(psm_list=[psm for psm in self.__iter__()])
 
     @staticmethod
     def _parse_peptidoform(sequence: str, charge: int):
@@ -67,6 +67,8 @@ class IdXMLReader(ReaderBase):
             return False
         elif target_decoy == "decoy":
             return True
+        elif target_decoy == "target+decoy":
+            return False
         else:
             return None
 

--- a/psm_utils/io/maxquant.py
+++ b/psm_utils/io/maxquant.py
@@ -52,6 +52,8 @@ class MSMSReader(ReaderBase):
     def __init__(
         self,
         filename: Union[str, Path],
+        *args,
+        **kwargs,
     ) -> None:
         """
         Reader for MaxQuant msms.txt PSM files.
@@ -84,7 +86,7 @@ class MSMSReader(ReaderBase):
 
         """
 
-        super().__init__(filename)
+        super().__init__(filename, *args, **kwargs)
 
         self._rename_mapping = None
         self._mass_error_unit = None
@@ -99,9 +101,6 @@ class MSMSReader(ReaderBase):
                 psm = self._get_peptide_spectrum_match(psm_dict)
                 yield psm
 
-    def __next__(self) -> PeptideSpectrumMatch:
-        return super().__next__()
-
     def read_file(self) -> PSMList:
         """Read full MaxQuant msms.txt PSM file into a PSMList object."""
         psm_list = []
@@ -109,7 +108,7 @@ class MSMSReader(ReaderBase):
             reader = csv.DictReader(msms_in, delimiter="\t")
             for psm_dict in reader:
                 psm_list.append(self._get_peptide_spectrum_match(psm_dict))
-        return PSMList(psm_list)
+        return PSMList(psm_list=psm_list)
 
     def _validate_msms(self) -> None:
         with open(self.filename, "r") as msms_file:

--- a/psm_utils/io/peptide_record.py
+++ b/psm_utils/io/peptide_record.py
@@ -156,6 +156,8 @@ class PeptideRecordReader(ReaderBase):
     def __init__(
         self,
         filename: Union[str, Path],
+        *args,
+        **kwargs,
     ) -> None:
         """
         Reader for Peptide Record PSM files.
@@ -185,7 +187,7 @@ class PeptideRecordReader(ReaderBase):
 
         """
 
-        super().__init__(filename)
+        super().__init__(filename, *args, **kwargs)
         self._peprec = _PeptideRecord(self.filename)
 
         # Define named tuple for single Peptide Record entries, based on
@@ -212,7 +214,7 @@ class PeptideRecordReader(ReaderBase):
             for row in reader:
                 entry = self.PeprecEntry(**row)
                 psm_list.append(self._entry_to_psm(entry, filename=self.filename))
-        return PSMList(psm_list)
+        return PSMList(psm_list=psm_list)
 
     @staticmethod
     def _entry_to_psm(
@@ -246,7 +248,7 @@ class PeptideRecordReader(ReaderBase):
 
 
 class PeptideRecordWriter(WriterBase):
-    def __init__(self, filename):
+    def __init__(self, filename, *args, **kwargs):
         """
         Writer for Peptide Record PSM files.
 
@@ -256,7 +258,7 @@ class PeptideRecordWriter(WriterBase):
             Path to PSM file
 
         """
-        super().__init__(filename)
+        super().__init__(filename, *args, **kwargs)
         self._open_file = None
         self._writer = None
 
@@ -294,7 +296,7 @@ class PeptideRecordWriter(WriterBase):
             "spec_id": psm.spectrum_id,
             "peptide": sequence,
             "modifications": modifications,
-            "charge": charge if charge else psm.precursor_charge,
+            "charge": charge,
             "label": None if psm.is_decoy is None else -1 if psm.is_decoy else 1,
             "observed_retention_time": psm.retention_time,
             "score": psm.score,
@@ -430,7 +432,7 @@ def proforma_to_peprec(peptidoform: Peptidoform) -> tuple(str, str, Optional[int
             raise InvalidPeprecModificationError(
                 "Multiple modifications per site not supported in Peptide Record format."
             )
-        return "|".join([str(location), mod_list[0].value])
+        return "|".join([str(location), str(mod_list[0].value)])
 
     ms2pip_mods = []
     if peptidoform.properties["n_term"]:

--- a/psm_utils/io/tsv.py
+++ b/psm_utils/io/tsv.py
@@ -62,8 +62,8 @@ from psm_utils.psm_list import PSMList
 class TSVReader(ReaderBase):
     """Reader for psm_utils TSV format."""
 
-    def __init__(self, filename: Union[str, Path]) -> None:
-        super().__init__(filename)
+    def __init__(self, filename: Union[str, Path], *args, **kwargs) -> None:
+        super().__init__(filename, *args, **kwargs)
 
     def __iter__(self):
         """Iterate over file and return PSMs one-by-one."""
@@ -74,7 +74,7 @@ class TSVReader(ReaderBase):
 
     def read_file(self) -> PSMList:
         """Read full PSM file into a PSMList object."""
-        return PSMList([psm for psm in self.__iter__()])
+        return PSMList(psm_list=[psm for psm in self.__iter__()])
 
     @staticmethod
     def _parse_entry(entry: dict):
@@ -119,6 +119,8 @@ class TSVWriter(WriterBase):
         self,
         filename: Union[str, Path],
         example_psm: Optional[PeptideSpectrumMatch] = None,
+        *args,
+        **kwargs,
     ):
         """
         Reader for psm_utils TSV format.
@@ -136,7 +138,7 @@ class TSVWriter(WriterBase):
             they are present in other PSMs passed to :py:meth:`write_psm` or
             :py:meth:`write_file`.
         """
-        super().__init__(filename)
+        super().__init__(filename, *args, **kwargs)
 
         self._open_file = None
         self._writer = None
@@ -213,7 +215,7 @@ class TSVWriter(WriterBase):
 
     @staticmethod
     def _psm_to_entry(psm: PeptideSpectrumMatch) -> dict:
-        entry = dataclasses.asdict(psm)
+        entry = psm.__dict__
 
         # Convert Peptidoform to proforma sequence
         entry["peptide"] = entry["peptide"].proforma

--- a/psm_utils/io/xtandem.py
+++ b/psm_utils/io/xtandem.py
@@ -106,7 +106,7 @@ class XTandemReader(ReaderBase):
         with tandem.read(str(self.filename)) as reader:
             for entry in reader:
                 psm_list.append(self._parse_entry(entry))
-        return PSMList(psm_list)
+        return PSMList(psm_list=psm_list)
 
     def _parse_peptidoform(self, peptide_entry, charge: int) -> Peptidoform:
         """Parse X!Tandem XML peptide entry to :py:class:`~psm_utils.peptidoform.Peptidoform`."""
@@ -161,7 +161,7 @@ class XTandemReader(ReaderBase):
             protein_list=[entry["protein"][0]["label"]],
             source="X!Tandem",
             provenance_data={
-                "xtandem_filename": self.filename,
+                "xtandem_filename": str(self.filename),
                 "xtandem_id": entry["id"],
             },
             metadata={

--- a/psm_utils/peptidoform.py
+++ b/psm_utils/peptidoform.py
@@ -51,6 +51,11 @@ class Peptidoform:
         return "".join(pos[0] for pos in self.parsed_sequence)
 
     @property
+    def precursor_charge(self) -> int:
+        """Syntactic sugar for `Peptidoform.properties['charge_state'].charge`."""
+        return self.properties["charge_state"].charge
+
+    @property
     def sequential_composition(self) -> list[mass.Composition]:
         """Atomic compositions of both termini and each (modified) residue."""
         # Get compositions for fixed modifications by amino acid

--- a/psm_utils/psm_list.py
+++ b/psm_utils/psm_list.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Iterable, Union
+import re
+from typing import Iterable, List, Sequence, Union
+
+import numpy as np
+import pandas as pd
+import pyteomics
+from pydantic import BaseModel
 
 from psm_utils.psm import PeptideSpectrumMatch
 
 
-@dataclass
-class PSMList:
+class PSMList(BaseModel):
     """
     Data class representing a list of PSMs.
 
@@ -20,7 +24,7 @@ class PSMList:
     --------
     Initiate a :py:class:`PSMList` from a list of PeptideSpectrumMatch objects:
 
-    >>> psm_list = PSMList([
+    >>> psm_list = PSMList(psm_list=[
     ...     PeptideSpectrumMatch(peptide="ACDK", spectrum_id=1),
     ...     PeptideSpectrumMatch(peptide="CDEFR", spectrum_id=2),
     ...     PeptideSpectrumMatch(peptide="DEM[Oxidation]K", spectrum_id=3),
@@ -42,22 +46,94 @@ class PSMList:
 
     """
 
-    # TODO
-    # __slots__ = ()
-
-    psm_list: list[PeptideSpectrumMatch]
+    psm_list: List[PeptideSpectrumMatch]
 
     def __iter__(self) -> Iterable[PeptideSpectrumMatch]:
         return self.psm_list.__iter__()
 
-    def __getitem__(
-        self, idx
-    ) -> Union[PeptideSpectrumMatch, list[PeptideSpectrumMatch]]:
-        # TODO: Expand usage? E.g. index by spectrum_id? Return new PSMList for slice?
-        return self.psm_list[idx]
-
     def __len__(self) -> int:
         return self.psm_list.__len__()
+
+    def __getitem__(
+        self, item
+    ) -> Union[PeptideSpectrumMatch, list[PeptideSpectrumMatch]]:
+        # TODO: Expand usage? E.g. index by spectrum_id? Return new PSMList for slice?
+        if isinstance(item, int):
+            return self.psm_list[item]
+        elif isinstance(item, slice):
+            return PSMList(psm_list=self.psm_list[item])
+        elif isinstance(item, str):
+            return np.array([psm[item] for psm in self.psm_list])
+
+    def __setitem__(self, item, values: Sequence) -> None:
+        if not len(values) == len(self):
+            raise ValueError(f"Expected value with same length as PSMList: {len(self)}")
+        for value, psm in zip(values, self):
+            psm[item] = value
+
+    def find_decoys(self, decoy_pattern: str) -> None:
+        """
+        Use regular expression pattern to find decoy PSMs by protein name(s).
+
+        This method allows a regular expression pattern to be applied on
+        :py:obj:`~psm_utils.psm.PeptideSpectrumMatch`
+        :py:attr:`~psm_utils.psm.PeptideSpectrumMatch.protein_list` items to set the
+        :py:attr:`~psm_utils.psm.PeptideSpectrumMatch.is_decoy` attribute.
+        Decoy protein entries are commonly marked with a prefix or suffix, e.g.
+        ``DECOY_``, or ``_REVERSED``. If ``decoy_pattern`` matches to a substring of all
+        entries in :py:attr:`protein_list`, the PSM is interpreted as a decoy. Existing
+        :py:attr:`is_decoy` entries are overwritten.
+
+        Parameters
+        ----------
+        decoy_pattern: str
+            Regular expression pattern to match decoy protein entries.
+
+        Examples
+        --------
+        >>> psm_list.find_decoys(r"^DECOY_")
+
+        """
+        decoy_pattern = re.compile(decoy_pattern)
+        for psm in self:
+            psm.is_decoy = all(
+                [decoy_pattern.search(p) is not None for p in psm.protein_list]
+            )
+
+    def calculate_qvalues(self, reverse: bool = True, **kwargs) -> None:
+        """
+        Calculate q-values using the target-decoy approach.
+
+        Q-values are calculated for all PSMs from the target and decoy scores. This
+        requires that all PSMs have a :py:attr:`score` and a target/decoy state
+        (:py:attr:`is_decoy`) assigned. Any existing q-values will be overwritten.
+
+        Parameters
+        ----------
+        reverse: boolean, optional
+            If True (default), a higher score value indicates a better PSM.
+        **kwargs : dict, optional
+            Additional arguments to be passed to
+            `pyteomics.auxiliary.target_decoy.qvalues <https://pyteomics.readthedocs.io/en/latest/api/auxiliary.html#pyteomics.auxiliary.target_decoy.qvalues>`_.
+
+        """
+        for key in ["score", "is_decoy"]:
+            if (self[key] == None).any():
+                raise ValueError(
+                    f"Cannot calculate q-values if not all PSMs have `{key}` assigned."
+                )
+
+        qvalues = pyteomics.auxiliary.qvalues(
+            self,
+            key="score",
+            is_decoy="is_decoy",
+            remove_decoy=False,
+            reverse=reverse,
+            full_output=True,
+            **kwargs,
+        )
+        for score, is_decoy, qvalue, psm in qvalues:
+            psm.qvalue = qvalue
 
     def rename_modifications(self, mapping: dict[str, str]) -> None:
         """
@@ -85,3 +161,7 @@ class PSMList:
     def to_csv(self) -> None:  # Or "to_dataframe"?
         """Write PSMList to comma-separated values file."""
         raise NotImplementedError
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Convert :py:class:`PSMList` to :py:class:`pandas.DataFrame`."""
+        return pd.DataFrame.from_records([psm.__dict__ for psm in self])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,10 @@ doc = [
     "sphinx_rtd_theme",
     "sphinx-autobuild",
 ]
+online = [
+    "streamlit",
+    "plotly",
+]
 
 [project.urls]
 GitHub = "https://github.com/compomics/psm_utils"

--- a/tests/test_io/test___init__.py
+++ b/tests/test_io/test___init__.py
@@ -1,0 +1,26 @@
+"""Tests for psm_utils.io.__init__."""
+
+import pytest
+
+from psm_utils.io import _infer_filetype
+from psm_utils.io.exceptions import PSMUtilsIOException
+
+
+def test__infer_filetype():
+    test_cases = [
+        ("name.idxml", "idxml"),
+        ("name.idXML", "idxml"),
+        ("msms.txt", "msms"),
+        ("name.peprec", "peprec"),
+        ("name.peprec.txt", "peprec"),
+        ("name.pin", "percolator"),
+        ("name.pout", "percolator"),
+        ("name.t.xml", "xtandem"),
+    ]
+    for test_in, expected_out in test_cases:
+        assert _infer_filetype(test_in) == expected_out
+
+    test_cases = ["name.txt", "name.idxml.txt", "name.csv", "name.msms.txt", "msms.csv"]
+    for test_in in test_cases:
+        with pytest.raises(PSMUtilsIOException):
+            _infer_filetype(test_in)


### PR DESCRIPTION
Add **psm_utils online** webserver

Expand PSMList functionality:
  - Fully switch to Pydantic BaseModel (`psm_list` should always be a keyword argument now)
  - Add `__len__` method
  - Expand `__getitem__`: Allow slice of PSMList; allow string value to get PSMList-wide array of a PSM property
  - Add `__setitem__` method: Set PSMList-wide array of a PSM property
  - Add `find_decoys` method
  - Add `calculate_qvalues` method
  - Add `to_dataframe` method

Expand PeptideSpectrumMatch functionality:
  - Fully switch to Pydantic BaseModel
  - Add `__getitem__` and `__setitem__` methods: "Square bracket-type access" to fields, e.g., `psm["qvalue"]`
  - Add `qvalue` and `pep` fields
  - Replace `precursor_charge` property with `get_precursor_charge` method (compatibility with Pydantic)
  - Remove obsolete `to_peprec_entry` method (see psm_utils.io.peptide_record)

Peptidoform:
  - Add `precursor_charge` property

Various psm_utils.io changes
  - Add *args and **kwargs to all readers and writers to allow filetype specific arguments through generic read_file and write_file functions.
  - Rewrite global dict FILETYPES
  - Implement `_infer_filetype` function
  - `convert`: Support writers that require an example PSM
  - Various minor fixes
  - percolator: Add support for POUT files; Add join_pout_files function