### PR TITLE
Minor fixes

### DIFF
--- a/psm_utils/__init__.py
+++ b/psm_utils/__init__.py
@@ -2,6 +2,16 @@
 
 __version__ = "0.2.3"
 
+from warnings import filterwarnings
+
+# mzmlb is not used, so hdf5plugin is not needed
+filterwarnings(
+    "ignore",
+    message="hdf5plugin is missing",
+    category=UserWarning,
+    module="psims.mzmlb",
+)
+
 from psm_utils.peptidoform import Peptidoform
 from psm_utils.psm import PSM
 from psm_utils.psm_list import PSMList

--- a/psm_utils/io/mzid.py
+++ b/psm_utils/io/mzid.py
@@ -176,11 +176,24 @@ class MzidReader(ReaderBase):
 
     @staticmethod
     def _parse_peptide_evidence_ref(peptide_evidence_list: list[dict]):
-        """Parse peptide evidence References of PSM."""
-        try:
-            isdecoy = peptide_evidence_list[0]["isDecoy"]
-        except KeyError:
-            isdecoy = None
+        """
+        Parse PeptideEvidence list of PSM.
+
+        Notes
+        -----
+        If multiple PeptideEvidence entries are associated with the PSM, the PSM is only considered
+        a decoy entry if ALL PeptideEvidence entries are decoy entries. If a target PeptideEvidence
+        entry is present, it should get priority over decoy entries. In theory, no overlap between
+        target and decoy peptide sequence should be present in the search space, although this
+        might not have been filtered for by the search engine.
+
+        """
+        isdecoy = all(
+            [
+                entry["is_decoy"] if "is_decoy" in entry else None
+                for entry in peptide_evidence_list
+            ]
+        )
         protein_list = [
             d["accession"] for d in peptide_evidence_list if "accession" in d.keys()
         ]

--- a/psm_utils/io/mzid.py
+++ b/psm_utils/io/mzid.py
@@ -190,7 +190,7 @@ class MzidReader(ReaderBase):
         """
         isdecoy = all(
             [
-                entry["is_decoy"] if "is_decoy" in entry else None
+                entry["isDecoy"] if "isDecoy" in entry else None
                 for entry in peptide_evidence_list
             ]
         )

--- a/psm_utils/io/mzid.py
+++ b/psm_utils/io/mzid.py
@@ -177,7 +177,10 @@ class MzidReader(ReaderBase):
     @staticmethod
     def _parse_peptide_evidence_ref(peptide_evidence_list: list[dict]):
         """Parse peptide evidence References of PSM."""
-        isdecoy = peptide_evidence_list[0]["isDecoy"]
+        try:
+            isdecoy = peptide_evidence_list[0]["isDecoy"]
+        except KeyError:
+            isdecoy = None
         protein_list = [
             d["accession"] for d in peptide_evidence_list if "accession" in d.keys()
         ]

--- a/psm_utils/io/tsv.py
+++ b/psm_utils/io/tsv.py
@@ -80,7 +80,12 @@ class TSVReader(ReaderBase):
 
         # Parse protein list
         if "protein_list" in entry and entry["protein_list"]:
-            entry["protein_list"] = ast.literal_eval(entry["protein_list"])
+            try:
+                entry["protein_list"] = ast.literal_eval(entry["protein_list"])
+            except ValueError:
+                raise PSMUtilsIOException(
+                    f"Could not parse protein list: `{entry['protein_list']}`"
+                )
 
         # Extract dict properties
         parsed_entry = {}

--- a/psm_utils/psm_list.py
+++ b/psm_utils/psm_list.py
@@ -88,7 +88,7 @@ class PSMList(BaseModel):
         return self.psm_list.__len__()
 
     def __getitem__(self, item) -> PSM | list[PSM]:
-        if isinstance(item, int):
+        if isinstance(item, (int, np.integer)):
             # Return single PSM by index
             return self.psm_list[item]
         elif isinstance(item, slice):


### PR DESCRIPTION
### Added
- Filter warnings from `psims.mzmlb` on import, as `mzmlb` is not used

### Changed
- `PSMList`: Also allow Numpy integers for indexing a single PSM

### Fixed
- `io.tsv`: Raise `PSMUtilsIOException` with clear error message when TSV `protein_list` cannot be read
- `io.mzid`: Consider all `PeptideEvidence` entries for a `SpectrumIdentificationItem` to determine `is_decoy`
- `io.mzid`: Fix handling of mzIdentML files when `is_decoy` field is not present (fixes #30)