### PR TITLE
Minor improvements

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ python:
       path: .
       extra_requirements:
         - dev
-        - doc
+        - docs
 
 sphinx:
   builder: dirhtml

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -40,7 +40,7 @@ Local install
 
 .. code-block:: sh
 
-    pip install --editable .[dev,doc]
+    pip install --editable .[dev,docs]
 
 
 
@@ -62,7 +62,7 @@ and run ``sphinx-autobuild``:
 
 .. code-block:: sh
 
-    pip install .[doc]
+    pip install .[docs]
     sphinx-autobuild  --watch ./psm_utils ./docs/source/ ./docs/_build/html/
 
 Then browse to http://localhost:8000 to watch the live preview.

--- a/docs/source/api/psm_utils.rst
+++ b/docs/source/api/psm_utils.rst
@@ -26,3 +26,10 @@ psm_utils.psm_list
    :members:
 
 
+psm_utils.utils
+###############
+
+.. automodule:: psm_utils.utils
+   :members:
+
+

--- a/psm_utils/io/peptide_record.py
+++ b/psm_utils/io/peptide_record.py
@@ -328,11 +328,11 @@ class PeptideRecordWriter(WriterBase):
         entry = self._psm_to_entry(psm)
         try:
             self._writer.writerow(entry)
-        except AttributeError:
+        except AttributeError as e:
             raise PSMUtilsIOException(
                 f"`write_psm` method can only be called if `{self.__class__.__qualname__}`"
                 "is opened in context (i.e., using the `with` statement)."
-            )
+            ) from e
 
     # TODO: Support appending to existing file?
     def write_file(self, psm_list: PSMList):
@@ -396,14 +396,14 @@ def peprec_to_proforma(
     ):
         try:
             peptide[int(position)] += f"[{label}]"
-        except ValueError:
+        except ValueError as e:
             raise InvalidPeprecModificationError(
                 f"Could not parse PEPREC modification `{modifications}`."
-            )
-        except IndexError:
+            ) from e
+        except IndexError as e:
             raise InvalidPeprecModificationError(
                 f"PEPREC modification has invalid position {position} in peptide `{''.join(peptide)}`."
-            )
+            ) from e
 
     # Add dashes between residues and termini, and join sequence
     peptide[0] = peptide[0] + "-" if peptide[0] else ""

--- a/psm_utils/io/percolator.py
+++ b/psm_utils/io/percolator.py
@@ -323,11 +323,11 @@ class PercolatorTabWriter(WriterBase):
             entry["ScanNr"] = None
         try:
             self._writer.writerow(entry)
-        except AttributeError:
+        except AttributeError as e:
             raise PSMUtilsIOException(
                 f"`write_psm` method can only be called if `{self.__class__.__qualname__}`"
                 "is opened in context (i.e., using the `with` statement)."
-            )
+            ) from e
         else:
             self._last_scan_number = entry["ScanNr"]
 

--- a/psm_utils/io/tsv.py
+++ b/psm_utils/io/tsv.py
@@ -82,10 +82,10 @@ class TSVReader(ReaderBase):
         if "protein_list" in entry and entry["protein_list"]:
             try:
                 entry["protein_list"] = ast.literal_eval(entry["protein_list"])
-            except ValueError:
+            except ValueError as e:
                 raise PSMUtilsIOException(
                     f"Could not parse protein list: `{entry['protein_list']}`"
-                )
+                ) from e
 
         # Extract dict properties
         parsed_entry = {}
@@ -192,11 +192,11 @@ class TSVWriter(WriterBase):
         entry = self._psm_to_entry(psm)
         try:
             self._writer.writerow(entry)
-        except AttributeError:
+        except AttributeError as e:
             raise PSMUtilsIOException(
                 f"`write_psm` method can only be called if `{self.__class__.__qualname__}`"
                 "is opened in context (i.e., using the `with` statement)."
-            )
+            ) from e
 
     def write_file(self, psm_list: PSMList):
         """

--- a/psm_utils/peptidoform.py
+++ b/psm_utils/peptidoform.py
@@ -4,6 +4,7 @@ from pyteomics import mass, proforma
 import numpy as np
 
 from psm_utils.exceptions import PSMUtilsException
+from psm_utils.utils import mass_to_mz
 
 
 class Peptidoform:
@@ -353,10 +354,7 @@ class Peptidoform:
 
         """
         if self.precursor_charge:
-            return (
-                self.theoretical_mass
-                + (mass.nist_mass["H"][1][0] * self.precursor_charge)
-            ) / self.precursor_charge
+            return mass_to_mz(self.theoretical_mass, self.precursor_charge)
         else:
             return None
 

--- a/psm_utils/peptidoform.py
+++ b/psm_utils/peptidoform.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from pyteomics import mass, proforma
 import numpy as np
+from pyteomics import mass, proforma
 
 from psm_utils.exceptions import PSMUtilsException
 from psm_utils.utils import mass_to_mz
@@ -35,7 +35,12 @@ class Peptidoform:
             Dict with sequence-wide properties.
 
         """
-        self.parsed_sequence, self.properties = proforma.parse(proforma_sequence)
+        try:
+            self.parsed_sequence, self.properties = proforma.parse(proforma_sequence)
+        except proforma.ProFormaError as e:
+            raise PeptidoformException(
+                f"Could not parse ProForma sequence: {proforma_sequence}"
+            ) from e
 
         if self.properties["isotopes"]:
             raise NotImplementedError(

--- a/psm_utils/peptidoform.py
+++ b/psm_utils/peptidoform.py
@@ -60,7 +60,7 @@ class Peptidoform:
         try:
             return self.proforma == __o.proforma
         except AttributeError:
-            raise NotImplemented("Object is not a Peptidoform")
+            raise NotImplementedError("Object is not a Peptidoform")
 
     @property
     def proforma(self) -> str:
@@ -161,10 +161,10 @@ class Peptidoform:
             for tag in self.properties["n_term"]:
                 try:
                     n_term += tag.composition
-                except (AttributeError, KeyError):
+                except (AttributeError, KeyError) as e:
                     raise ModificationException(
                         f"Cannot resolve composition for modification {tag.value}."
-                    )
+                    ) from e
         comp_list.append(n_term)
 
         # Sequence
@@ -172,10 +172,10 @@ class Peptidoform:
             # Amino acid
             try:
                 position_comp = mass.std_aa_comp[aa].copy()
-            except (AttributeError, KeyError):
+            except (AttributeError, KeyError) as e:
                 raise AmbiguousResidueException(
                     f"Cannot resolve composition for amino acid {aa}."
-                )
+                ) from e
             # Fixed modifications
             if aa in fixed_rules:
                 position_comp += fixed_rules[aa]
@@ -184,11 +184,11 @@ class Peptidoform:
                 for tag in tags:
                     try:
                         position_comp += tag.composition
-                    except (AttributeError, KeyError):
+                    except (AttributeError, KeyError) as e:
                         raise ModificationException(
                             "Cannot resolve composition for modification "
                             f"{tag.value}."
-                        )
+                        ) from e
             comp_list.append(position_comp)
 
         # C-terminus
@@ -197,10 +197,10 @@ class Peptidoform:
             for tag in self.properties["c_term"]:
                 try:
                     c_term += tag.composition
-                except (AttributeError, KeyError):
+                except (AttributeError, KeyError) as e:
                     raise ModificationException(
                         f"Cannot resolve composition for modification {tag.value}."
-                    )
+                    ) from e
         comp_list.append(c_term)
 
         return comp_list
@@ -224,17 +224,17 @@ class Peptidoform:
         for tag in self.properties["labile_modifications"]:
             try:
                 comp += tag.composition
-            except (AttributeError, KeyError):
+            except (AttributeError, KeyError) as e:
                 raise ModificationException(
                     f"Cannot resolve composition for modification {tag.value}."
-                )
+                ) from e
         for tag in self.properties["unlocalized_modifications"]:
             try:
                 comp += tag.composition
-            except (AttributeError, KeyError):
+            except (AttributeError, KeyError) as e:
                 raise ModificationException(
                     f"Cannot resolve composition for modification {tag.value}."
-                )
+                ) from e
         return comp
 
     @property
@@ -270,10 +270,10 @@ class Peptidoform:
             for tag in self.properties["n_term"]:
                 try:
                     n_term += tag.mass
-                except (AttributeError, KeyError):
+                except (AttributeError, KeyError) as e:
                     raise ModificationException(
                         f"Cannot resolve mass for modification {tag.value}."
-                    )
+                    ) from e
         mass_list.append(n_term)
 
         # Sequence
@@ -281,10 +281,10 @@ class Peptidoform:
             # Amino acid
             try:
                 position_mass = mass.std_aa_mass[aa]
-            except (AttributeError, KeyError):
+            except (AttributeError, KeyError) as e:
                 raise AmbiguousResidueException(
                     f"Cannot resolve mass for amino acid {aa}."
-                )
+                ) from e
             # Fixed modifications
             if aa in fixed_rules:
                 position_mass += fixed_rules[aa]
@@ -293,10 +293,10 @@ class Peptidoform:
                 for tag in tags:
                     try:
                         position_mass += tag.mass
-                    except (AttributeError, KeyError):
+                    except (AttributeError, KeyError) as e:
                         raise ModificationException(
                             "Cannot resolve mass for modification " f"{tag.value}."
-                        )
+                        ) from e
             mass_list.append(position_mass)
 
         # C-terminus
@@ -305,10 +305,10 @@ class Peptidoform:
             for tag in self.properties["c_term"]:
                 try:
                     c_term += tag.mass
-                except (AttributeError, KeyError):
+                except (AttributeError, KeyError) as e:
                     raise ModificationException(
                         f"Cannot resolve mass for modification {tag.value}."
-                    )
+                    ) from e
         mass_list.append(c_term)
 
         return mass_list
@@ -329,17 +329,17 @@ class Peptidoform:
         for tag in self.properties["labile_modifications"]:
             try:
                 mass += tag.mass
-            except (AttributeError, KeyError):
+            except (AttributeError, KeyError) as e:
                 raise ModificationException(
                     f"Cannot resolve mass for modification {tag.value}."
-                )
+                ) from e
         for tag in self.properties["unlocalized_modifications"]:
             try:
                 mass += tag.mass
-            except (AttributeError, KeyError):
+            except (AttributeError, KeyError) as e:
                 raise ModificationException(
                     f"Cannot resolve mass for modification {tag.value}."
-                )
+                ) from e
         return mass
 
     @property

--- a/psm_utils/psm_list.py
+++ b/psm_utils/psm_list.py
@@ -221,7 +221,7 @@ class PSMList(BaseModel):
 
         """
         for key in ["score", "is_decoy"]:
-            if (self[key] == None).any():
+            if (self[key] is None).any():
                 raise ValueError(
                     f"Cannot calculate q-values if not all PSMs have `{key}` assigned."
                 )

--- a/psm_utils/psm_list.py
+++ b/psm_utils/psm_list.py
@@ -81,6 +81,9 @@ class PSMList(BaseModel):
     def __str__(self):
         return self.__repr__()
 
+    def __add__(self, other):
+        return PSMList(psm_list=self.psm_list + other.psm_list)
+
     def __iter__(self) -> Iterable[PSM]:
         return self.psm_list.__iter__()
 

--- a/psm_utils/utils.py
+++ b/psm_utils/utils.py
@@ -1,0 +1,43 @@
+"""Various utility functions."""
+
+from typing import Optional
+
+from pyteomics.mass import nist_mass
+
+
+def mass_to_mz(mass: float, charge: int, adduct_mass: Optional[float] = None) -> float:
+    """
+    Convert mass to m/z.
+
+    Parameters
+    ----------
+    mass
+        Mass of the uncharged ion without adducts.
+    charge
+        Charge of the ion.
+    adduct_mass
+        Mass of the charge-carrying adduct. Defaults to the mass of a proton.
+
+    """
+    if adduct_mass is None:
+        adduct_mass = nist_mass["H"][1][0]
+    return (mass + charge * adduct_mass) / charge
+
+
+def mz_to_mass(mz: float, charge: int, adduct_mass: Optional[float] = None) -> float:
+    """
+    Convert m/z to mass.
+
+    Parameters
+    ----------
+    mz
+        m/z of the charged ion and adducts.
+    charge
+        Charge of the ion.
+    adduct_mass
+        Mass of the charge-carrying adduct. Defaults to the mass of a proton.
+
+    """
+    if adduct_mass is None:
+        adduct_mass = nist_mass["H"][1][0]
+    return mz * charge - charge * adduct_mass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
     "pytest",
     "pytest-cov"
 ]
-doc = [
+docs = [
     "sphinx",
     "numpydoc>=1,<2",
     "recommonmark",
@@ -70,3 +70,7 @@ name = "psm_utils"
 
 [tool.isort]
 profile = "black"
+
+[tool.black]
+line-length = 99
+target-version = ['py37']


### PR DESCRIPTION
### Added

- Add + operator support for `PSMList`
- Add utility functions for m/z-mass conversion in new module `psm_utils.utils`
- `io.peptide_record`: Catch `ProFormaError` and reraise `InvalidPEPRECModificationError` with invalid peptidoform in message

### Changed

- Rename optional dependency `doc` to `docs`
- Implement "raise from e" when applicable throughout package
