### PR TITLE
Catch invalid position of modification in peptide

### DIFF
--- a/psm_utils/io/peptide_record.py
+++ b/psm_utils/io/peptide_record.py
@@ -400,6 +400,10 @@ def peprec_to_proforma(
             raise InvalidPeprecModificationError(
                 f"Could not parse PEPREC modification `{modifications}`."
             )
+        except IndexError:
+            raise InvalidPeprecModificationError(
+                f"PEPREC modification has invalid position {position} in peptide `{''.join(peptide)}`."
+            )
 
     # Add dashes between residues and termini, and join sequence
     peptide[0] = peptide[0] + "-" if peptide[0] else ""

--- a/tests/test_io/test_peptide_record.py
+++ b/tests/test_io/test_peptide_record.py
@@ -46,9 +46,14 @@ class TestPeptideRecord:
             test_out = peprec_to_proforma(*test_in)
             assert test_out.proforma == expected_out
 
-        # Invalid case
-        with pytest.raises(InvalidPeprecModificationError):
-            peprec_to_proforma("ACDE", "|")
+        # Invalid cases
+        invalid_test_cases = [
+            ("ACDE", "|"),
+            ("ACDE", "8|Oxidation"),
+        ]
+        for test_in in invalid_test_cases:
+            with pytest.raises(InvalidPeprecModificationError):
+                peprec_to_proforma(*test_in)
 
 
 class TestPeptideRecordReader:


### PR DESCRIPTION
Catch the `IndexError` when a modification has a position that is out of range for the peptide, and raise an `InvalidPeprecModificationError` instead.