### PR TITLE
Revert comparison operator change from v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [0.4.1] - 2023-07-06
+
+## Fixed
+
+- `PSMList`: Revert comparison operator change from v0.4.0 that results in broken `calculate_qvalues()` method (E711; Numpy array, not singleton)
+
 # [0.4.0] - 2023-07-06
 
 ### Added

--- a/psm_utils/__init__.py
+++ b/psm_utils/__init__.py
@@ -1,6 +1,6 @@
 """Common utilities for parsing and handling PSMs, and search engine results."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 from warnings import filterwarnings
 

--- a/psm_utils/psm_list.py
+++ b/psm_utils/psm_list.py
@@ -221,7 +221,7 @@ class PSMList(BaseModel):
 
         """
         for key in ["score", "is_decoy"]:
-            if (self[key] is None).any():
+            if (self[key] == None).any():  # noqa: E711 (self[key] is a Numpy array)
                 raise ValueError(
                     f"Cannot calculate q-values if not all PSMs have `{key}` assigned."
                 )


### PR DESCRIPTION
## Fixed

- `PSMList`: Revert comparison operator change from v0.4.0 that results in broken `calculate_qvalues()` method (E711; Numpy array, not singleton)