### PR TITLE
Add len and iter methods to Peptidoform; fix mzid score_key usage

### DIFF
--- a/psm_utils/io/mzid.py
+++ b/psm_utils/io/mzid.py
@@ -133,7 +133,7 @@ class MzidReader(ReaderBase):
         """
         super().__init__(filename, *args, **kwargs)
         self._non_metadata_keys = ["ContactRole", "passThreshold"]
-        self._score_key = None
+        self._score_key = score_key
         self._rt_key = None
         self._spectrum_rt_key = None
         self._qvalue_key = None
@@ -260,16 +260,15 @@ class MzidReader(ReaderBase):
             psm_spectrum_id = spectrum_id
 
         try:
-            score = sii[self.score_key]
+            score = sii[self._score_key]
         except KeyError:
             score = None
-
         psm = PSM(
             peptidoform=peptidoform,
             spectrum_id=psm_spectrum_id,
             run=run,
             is_decoy=is_decoy,
-            score=sii[self._score_key] if self._score_key else None,
+            score=score,
             qvalue=sii[self._qvalue_key] if self._qvalue_key else None,
             pep=sii[self._pep_key] if self._pep_key else None,
             precursor_mz=precursor_mz,
@@ -295,7 +294,8 @@ class MzidReader(ReaderBase):
             "Modification",
         ]
         # Get the score key and add to default keys
-        self._score_key = self._infer_score_name(keys)
+        if not self._score_key:
+            self._score_key = self._infer_score_name(keys)
         if self._score_key:
             default_keys.append(self._score_key)
         else:

--- a/psm_utils/peptidoform.py
+++ b/psm_utils/peptidoform.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Iterable, List, Tuple, Union
+
 import numpy as np
 from pyteomics import mass, proforma
 
@@ -68,6 +70,12 @@ class Peptidoform:
             return self.proforma == __o.proforma
         except AttributeError:
             raise NotImplementedError("Object is not a Peptidoform")
+
+    def __iter__(self) -> Iterable[Tuple[str, Union[None, List[proforma.TagBase]]]]:
+        return self.parsed_sequence.__iter__()
+
+    def __len__(self) -> int:
+        return self.parsed_sequence.__len__()
 
     @property
     def proforma(self) -> str:

--- a/tests/test_peptidoform.py
+++ b/tests/test_peptidoform.py
@@ -1,7 +1,33 @@
+from pyteomics import proforma
+
 from psm_utils.peptidoform import Peptidoform
 
 
 class TestPeptidoform:
+
+    def test__len__(self):
+        test_cases = [
+            ("ACDEFGHIK", 9),
+            ("[ac]-AC[cm]DEFGHIK", 9),
+            ("[ac]-AC[Carbamidomethyl]DEFGHIK", 9),
+            ("[Acetyl]-AC[cm]DEFGK", 7),
+            ("<[cm]@C>[Acetyl]-ACDK", 4),
+            ("<[Carbamidomethyl]@C>[ac]-ACDEFGHIK", 9),
+        ]
+
+        for test_case_in, expected_out in test_cases:
+            peptidoform = Peptidoform(test_case_in)
+            assert len(peptidoform) == expected_out
+
+    def test__iter__(self):
+        for aa, mods in Peptidoform("ACDEM[U:35]K"):
+            assert isinstance(aa, str)
+            if mods is not None:
+                assert isinstance(mods, list)
+                for mod in mods:
+                    assert isinstance(mod, proforma.TagBase)
+
+
     def test_rename_modifications(self):
         label_mapping = {"ac": "Acetyl", "cm": "Carbamidomethyl"}
 


### PR DESCRIPTION
### Added
- `Peptidoform`: Add __iter__ and __len__ methods (inherit from `Peptidoform.parsed_sequence`)

### Fixed
- `io.mzid`: Fixed usage of `score_key` (bug introduced in unreleased #43)