### PR TITLE
Fix xtandem `run` value parsing; fix renaming negative mass modifications

### DIFF
--- a/psm_utils/io/xtandem.py
+++ b/psm_utils/io/xtandem.py
@@ -44,11 +44,11 @@ Notes
 
 from __future__ import annotations
 
+import logging
 import re
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Union
-import logging
 
 import numpy as np
 from pyteomics import mass, tandem
@@ -196,7 +196,8 @@ class XTandemReader(ReaderBase):
         else:
             run = Path(self.filepath).stem
             logger.warning(
-                f"Cannot parse run from X!Tandem XML label. Setting id file name `{run}` as run."
+                f"Could not parse run from X!Tandem XML label entry. Setting PSM filename `{run}` "
+                "as run."
             )
 
         return run

--- a/psm_utils/io/xtandem.py
+++ b/psm_utils/io/xtandem.py
@@ -48,6 +48,7 @@ import re
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Union
+import logging
 
 import numpy as np
 from pyteomics import mass, tandem
@@ -56,6 +57,8 @@ from psm_utils.exceptions import PSMUtilsException
 from psm_utils.io._base_classes import ReaderBase
 from psm_utils.peptidoform import Peptidoform
 from psm_utils.psm import PSM
+
+logger = logging.getLogger(__name__)
 
 
 class XTandemReader(ReaderBase):
@@ -187,9 +190,14 @@ class XTandemReader(ReaderBase):
         tree = ET.parse(str(filepath))
         root = tree.getroot()
         full_label = root.attrib["label"]
-        run_match = re.search(r"\/(?P<run>\d+_?\d+)\.(?P<filetype>mgf|mzML|mzml)", full_label)
+        run_match = re.search(r"\/(?P<run>[^\s\/\\]+)\.(?P<filetype>mgf|mzML|mzml)", full_label)
         if run_match:
             run = run_match.group("run")
+        else:
+            run = Path(self.filepath).stem
+            logger.warning(
+                f"Cannot parse run from X!Tandem XML label. Setting id file name `{run}` as run."
+            )
 
         return run
 

--- a/psm_utils/peptidoform.py
+++ b/psm_utils/peptidoform.py
@@ -520,7 +520,7 @@ class Peptidoform:
 def _format_number_as_string(num):
     """Format number as string for ProForma mass modifications."""
     sign = "+" if np.sign(num) == 1 else "-"
-    num = str(num).rstrip("0").rstrip(".")
+    num = str(num).rstrip("0").rstrip(".").lstrip("-")
     return sign + num
 
 

--- a/psm_utils/peptidoform.py
+++ b/psm_utils/peptidoform.py
@@ -519,9 +519,10 @@ class Peptidoform:
 
 def _format_number_as_string(num):
     """Format number as string for ProForma mass modifications."""
-    sign = "+" if np.sign(num) == 1 else "-"
-    num = str(num).rstrip("0").rstrip(".").lstrip("-")
-    return sign + num
+    # Using this method over `:+g` string formatting to avoid rounding and scientific notation
+    plus = "+" if np.sign(num) == 1 else ""  # Add plus sign if positive
+    num = str(num).rstrip("0").rstrip(".")  # Remove trailing zeros and decimal point
+    return plus + num
 
 
 class PeptidoformException(PSMUtilsException):

--- a/tests/test_peptidoform.py
+++ b/tests/test_peptidoform.py
@@ -27,7 +27,12 @@ class TestPeptidoform:
                     assert isinstance(mod, proforma.TagBase)
 
     def test_rename_modifications(self):
-        label_mapping = {"ac": "Acetyl", "cm": "Carbamidomethyl"}
+        label_mapping = {
+            "ac": "Acetyl",
+            "cm": "Carbamidomethyl",
+            "+57.021": "Carbamidomethyl",
+            "-18.010565": "Glu->pyro-Glu",
+        }
 
         test_cases = [
             ("ACDEFGHIK", "ACDEFGHIK"),
@@ -36,6 +41,9 @@ class TestPeptidoform:
             ("[Acetyl]-AC[cm]DEFGHIK", "[Acetyl]-AC[Carbamidomethyl]DEFGHIK"),
             ("<[cm]@C>[Acetyl]-ACDEFGHIK", "<[Carbamidomethyl]@C>[Acetyl]-ACDEFGHIK"),
             ("<[Carbamidomethyl]@C>[ac]-ACDEFGHIK", "<[Carbamidomethyl]@C>[Acetyl]-ACDEFGHIK"),
+            ("[ac]-AC[cm]DEFGHIK", "[Acetyl]-AC[Carbamidomethyl]DEFGHIK"),
+            ("AC[+57.021]DEFGHIK", "AC[Carbamidomethyl]DEFGHIK"),
+            ("E[-18.010565]DEK", "E[Glu->pyro-Glu]DEK"),
         ]
 
         for test_case_in, expected_out in test_cases:

--- a/tests/test_peptidoform.py
+++ b/tests/test_peptidoform.py
@@ -1,6 +1,6 @@
 from pyteomics import proforma
 
-from psm_utils.peptidoform import Peptidoform
+from psm_utils.peptidoform import Peptidoform, _format_number_as_string
 
 
 class TestPeptidoform:
@@ -50,3 +50,17 @@ class TestPeptidoform:
             peptidoform = Peptidoform(test_case_in)
             peptidoform.rename_modifications(label_mapping)
             assert peptidoform.proforma == expected_out
+
+
+def test_format_number_as_string():
+    test_cases = [
+        (1212.12, "+1212.12"),
+        (-1212.12, "-1212.12"),
+        (0.1, "+0.1"),
+        (-0.1, "-0.1"),
+        (1212.000, "+1212"),
+        (1212.1200, "+1212.12"),
+    ]
+
+    for test_case_in, expected_out in test_cases:
+        assert _format_number_as_string(test_case_in) == expected_out


### PR DESCRIPTION
### Added
- Tests: Added tests for _format_number_as_string function
- Tests: Added more test cases for `peptidoform.rename_modifications` for mass modifications
- `io.xtandem`: To parse `run` value, fall back to PSM file name if run name cannot be parsed from `label` field

### Fixed
- `peptidoform.rename_modifications`: Fixed mapping of negative mass modifications
- `io.xtandem`: Fixed regular expression to parse `run` value fom XML `label` field
