### PR TITLE
Fix bug in xtandem reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2023-11-29
+
+### Fixed
+- `io.xtandem`: Fixed bug when extracting run name (introduced in v0.7.0)
+
 ## [0.7.1] - 2023-10-30
 
 ### Added

--- a/psm_utils/__init__.py
+++ b/psm_utils/__init__.py
@@ -1,6 +1,6 @@
 """Common utilities for parsing and handling PSMs, and search engine results."""
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 
 from warnings import filterwarnings
 

--- a/psm_utils/io/xtandem.py
+++ b/psm_utils/io/xtandem.py
@@ -194,7 +194,7 @@ class XTandemReader(ReaderBase):
         if run_match:
             run = run_match.group("run")
         else:
-            run = Path(self.filepath).stem
+            run = Path(filepath).stem
             logger.warning(
                 f"Could not parse run from X!Tandem XML label entry. Setting PSM filename `{run}` "
                 "as run."


### PR DESCRIPTION
### Fixed
- `io.xtandem`: Fixed bug when extracting run name (introduced in v0.7.0)
