### PR TITLE
Add support for globally-defined terminal modifications

### DIFF
--- a/psm_utils/io/maxquant.py
+++ b/psm_utils/io/maxquant.py
@@ -14,7 +14,6 @@ from psm_utils.exceptions import PSMUtilsException
 from psm_utils.io._base_classes import ReaderBase
 from psm_utils.peptidoform import Peptidoform
 from psm_utils.psm import PSM
-from psm_utils.psm_list import PSMList
 
 logger = logging.getLogger(__name__)
 

--- a/psm_utils/io/tsv.py
+++ b/psm_utils/io/tsv.py
@@ -73,7 +73,7 @@ class TSVReader(ReaderBase):
             for row in reader:
                 try:
                     yield PSM(**self._parse_entry(row))
-                except ValidationError as e:
+                except ValidationError:
                     logger.warning("Could not parse PSM from row: `{row}`")
                     continue
 

--- a/psm_utils/peptidoform.py
+++ b/psm_utils/peptidoform.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import Iterable, List, Tuple, Union
 
 import numpy as np
@@ -14,7 +15,7 @@ class Peptidoform:
     Peptide sequence, modifications and charge state represented in ProForma notation.
     """
 
-    def __init__(self, proforma_sequence: [str, proforma.ProForma]) -> None:
+    def __init__(self, proforma_sequence: Union[str, proforma.ProForma]) -> None:
         """
         Peptide sequence, modifications and charge state represented in ProForma notation.
 
@@ -454,7 +455,7 @@ class Peptidoform:
 
         See also
         --------
-        psm_utils.peptidoform.Peptidoform.add_fixed_modifications
+        psm_utils.peptidoform.Peptidoform.apply_fixed_modifications
 
         Examples
         --------
@@ -462,6 +463,14 @@ class Peptidoform:
         >>> peptidoform.add_fixed_modifications([("Carbamidomethyl", ["C"])])
         >>> peptidoform.proforma
         '<[Carbamidomethyl]@C>ATPEILTCNSIGCLK'
+
+        Notes
+        -----
+        While globally defined terminal modifications are not explicitly supported in ProForma v2,
+        this function supports adding terminal modifications using the ``N-term`` and ``C-term``
+        targets in place of an amino acid target. These global modifications are supported in the
+        :py:meth:`psm_utils.peptidoform.Peptidoform.apply_fixed_modifications` method through a
+        workaround. See https://github.com/HUPO-PSI/ProForma/issues/6 for discussions on the issue.
 
         """
         if isinstance(modification_rules, dict):
@@ -497,13 +506,10 @@ class Peptidoform:
         """
         if self.properties["fixed_modifications"]:
             # Setup target_aa -> modification_list dictionary
-            rule_dict = {}
+            rule_dict = defaultdict(list)
             for rule in self.properties["fixed_modifications"]:
                 for target_aa in rule.targets:
-                    try:
-                        rule_dict[target_aa].append(rule.modification_tag)
-                    except KeyError:
-                        rule_dict[target_aa] = [rule.modification_tag]
+                    rule_dict[target_aa].append(rule.modification_tag)
 
             # Apply modifications to sequence
             for i, (aa, site_mods) in enumerate(self.parsed_sequence):
@@ -512,6 +518,14 @@ class Peptidoform:
                         self.parsed_sequence[i] = (aa, site_mods + rule_dict[aa])
                     else:
                         self.parsed_sequence[i] = (aa, rule_dict[aa])
+
+            # Apply terminal modifications
+            for term, term_name in [("n_term", "N-term"), ("c_term", "C-term")]:
+                if term_name in rule_dict:
+                    if self.properties[term]:
+                        self.properties[term].extend(rule_dict[term_name])
+                    else:
+                        self.properties[term] = rule_dict[term_name]
 
             # Remove fixed modifications
             self.properties["fixed_modifications"] = []
@@ -524,7 +538,6 @@ def format_number_as_string(num):
     plus = "+" if np.sign(num) == 1 else ""  # Add plus sign if positive
     num = str(num).rstrip("0").rstrip(".")  # Remove trailing zeros and decimal point
     return plus + num
-
 
 
 class PeptidoformException(PSMUtilsException):

--- a/tests/test_peptidoform.py
+++ b/tests/test_peptidoform.py
@@ -51,6 +51,20 @@ class TestPeptidoform:
             peptidoform.rename_modifications(label_mapping)
             assert peptidoform.proforma == expected_out
 
+    def test_add_apply_fixed_modifications(self):
+        test_cases = [
+            ("ACDEK", [("Cmm", ["C"])], "AC[Cmm]DEK"),
+            ("AC[Cmm]DEK", [("SecondMod", ["C"])], "AC[Cmm][SecondMod]DEK"),
+            ("ACDEK", [("TMT6plex", ["K", "N-term"])], "[TMT6plex]-ACDEK[TMT6plex]"),
+            ("ACDEK-[CT]", [("TMT6plex", ["K", "N-term"])], "[TMT6plex]-ACDEK[TMT6plex]-[CT]"),
+        ]
+
+        for test_case_in, fixed_modifications, expected_out in test_cases:
+            peptidoform = Peptidoform(test_case_in)
+            peptidoform.add_fixed_modifications(fixed_modifications)
+            peptidoform.apply_fixed_modifications()
+            assert peptidoform.proforma == expected_out
+
 
 def test_format_number_as_string():
     test_cases = [


### PR DESCRIPTION
### Added

- Support adding and applying global terminal modifications. For now using a workaround while waiting for official support and an implementation in Pyteomics. See HUPO-PSI/ProForma#6