### PR TITLE
Cache modification resolvers (temporary patch); version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2024-04-16
+
+### Added
+
+- Speed up mass calculation for large datasets by caching Proforma modification resolvers.
+  Temporary patch until implemented in Pyteomics (see levitsky/pyteomics#147).
+
 ## [0.8.2] - 2024-04-05
 
 ### Added

--- a/psm_utils/__init__.py
+++ b/psm_utils/__init__.py
@@ -1,7 +1,9 @@
 """Common utilities for parsing and handling PSMs, and search engine results."""
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"
+__all__ = ["Peptidoform", "PSM", "PSMList"]
 
+from functools import lru_cache
 from warnings import filterwarnings
 
 # mzmlb is not used, so hdf5plugin is not needed
@@ -12,6 +14,17 @@ filterwarnings(
     module="psims.mzmlb",
 )
 
-from psm_utils.peptidoform import Peptidoform  # noqa: E402, F401
-from psm_utils.psm import PSM  # noqa: E402, F401
-from psm_utils.psm_list import PSMList  # noqa: E402, F401
+from pyteomics.proforma import (  # noqa: E402
+    GenericResolver,
+    PSIModResolver,
+    UnimodResolver,
+)
+
+from psm_utils.peptidoform import Peptidoform  # noqa: E402
+from psm_utils.psm import PSM  # noqa: E402
+from psm_utils.psm_list import PSMList  # noqa: E402
+
+# Temporary patch until released in pyteomics (see levitsky/pyteomics#147)
+UnimodResolver.resolve = lru_cache(maxsize=None)(UnimodResolver.resolve)
+PSIModResolver.resolve = lru_cache(maxsize=None)(PSIModResolver.resolve)
+GenericResolver.resolve = lru_cache(maxsize=None)(GenericResolver.resolve)


### PR DESCRIPTION
### Added

- Speed up mass calculation for large datasets by caching Proforma modification resolvers.
  Temporary patch until implemented in Pyteomics (see levitsky/pyteomics#147).
