### PR TITLE
Update publish workflow to use build or setuptools instead of flit.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,21 +17,22 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.8"
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip flit pytest
+          python -m pip install --upgrade pip
+          pip install build
 
-      - name: Build 
-        run: flit build
+      - name: Build
+        run: python -m build --sdist --wheel .
 
-      - name: Install
+      - name: Install wheel
         run: pip install dist/psm_utils-*.whl
 
-      - name: Test package
+      - name: Test wheel
         run: |
           pytest
 


### PR DESCRIPTION
### Changed

- Update publish workflow to use Build and Setuptools instead of Flit.