### PR TITLE
Remove temporary patch for caching Proforma modification resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade Pydantic dependency to v2. The PSM `spectrum_id` field is now always coerced to a string.
 - `io.proteoscape`: Use pyarrow to iteratively read from Parquet instead of first reading an entire dataframe with Pandas.
 - `io.sage`: Update compatibility to Sage v0.14
+- Remove temporary patch for caching Proforma modification resolvers (now in Pyteomics v4.7.2).
 
 ## [0.8.3] - 2024-04-16
 

--- a/psm_utils/__init__.py
+++ b/psm_utils/__init__.py
@@ -3,7 +3,6 @@
 __version__ = "0.9.0"
 __all__ = ["Peptidoform", "PSM", "PSMList"]
 
-from functools import lru_cache
 from warnings import filterwarnings
 
 # mzmlb is not used, so hdf5plugin is not needed
@@ -14,17 +13,6 @@ filterwarnings(
     module="psims.mzmlb",
 )
 
-from pyteomics.proforma import (  # noqa: E402
-    GenericResolver,
-    PSIModResolver,
-    UnimodResolver,
-)
-
 from psm_utils.peptidoform import Peptidoform  # noqa: E402
 from psm_utils.psm import PSM  # noqa: E402
 from psm_utils.psm_list import PSMList  # noqa: E402
-
-# Temporary patch until released in pyteomics (see levitsky/pyteomics#147)
-UnimodResolver.resolve = lru_cache(maxsize=None)(UnimodResolver.resolve)
-PSIModResolver.resolve = lru_cache(maxsize=None)(PSIModResolver.resolve)
-GenericResolver.resolve = lru_cache(maxsize=None)(GenericResolver.resolve)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "pyarrow",
     "pydantic >= 2",
     "pyopenms",
-    "pyteomics >= 4, <4.7",
+    "pyteomics >= 4",
     "rich",
     "sqlalchemy",
 ]


### PR DESCRIPTION
### Changed

- Remove temporary patch for caching Proforma modification resolvers (now in Pyteomics v4.7.2).
