### PR TITLE
fix warning when parsing tsv

### DIFF
--- a/psm_utils/io/tsv.py
+++ b/psm_utils/io/tsv.py
@@ -78,7 +78,7 @@ class TSVReader(ReaderBase):
                 try:
                     yield PSM(**self._parse_entry(row))
                 except ValidationError:
-                    logger.warning("Could not parse PSM from row: `{row}`")
+                    logger.warning(f"Could not parse PSM from row: `{row}`")
                     continue
 
     @staticmethod


### PR DESCRIPTION
The warning when a PSM couldn't be parsed should be an f-string.