### PR TITLE
Improve TSV reading error handling

### DIFF
--- a/tests/test_data/test.tsv
+++ b/tests/test_data/test.tsv
@@ -1,0 +1,4 @@
+spectrum_id	peptidoform
+peptide1	ACDEK/2
+peptide2	AC[Carbamidomethyl]DEFGR/3
+peptide3	[Acetyl]-AC[Carbamidomethyl]DEFGHIK/2

--- a/tests/test_io/test_tsv.py
+++ b/tests/test_io/test_tsv.py
@@ -1,5 +1,8 @@
 """Tests for psm_utils.io.tsv."""
 
+import pytest
+
+from psm_utils.io.exceptions import PSMUtilsIOException  # noqa: F401
 from psm_utils.io.tsv import TSVReader, TSVWriter  # noqa: F401
 
 test_cases = [
@@ -30,3 +33,19 @@ class TestTSVReader:
     def test__parse_entry(self):
         for test_in, expected_out in test_cases:
             assert TSVReader._parse_entry(test_in) == expected_out
+
+    def test_iter(self):
+        reader = TSVReader("tests/test_data/test.tsv")
+        for psm in reader:
+            assert psm.peptidoform == "ACDEK/2"
+            assert psm.spectrum_id == "peptide1"
+            assert psm.provenance_data == {}
+            assert psm.metadata == {}
+            assert psm.rescoring_features == {}
+            break
+
+    def test_iter_raises(self):
+        with TSVReader("tests/test_data/peprec.tsv") as reader:
+            with pytest.raises(PSMUtilsIOException):
+                for psm in reader:
+                    pass

--- a/tests/test_io/test_tsv.py
+++ b/tests/test_io/test_tsv.py
@@ -2,8 +2,9 @@
 
 import pytest
 
-from psm_utils.io.exceptions import PSMUtilsIOException  # noqa: F401
-from psm_utils.io.tsv import TSVReader, TSVWriter  # noqa: F401
+from psm_utils.io.exceptions import PSMUtilsIOException
+from psm_utils.io.tsv import TSVReader
+from psm_utils.peptidoform import Peptidoform
 
 test_cases = [
     (
@@ -37,7 +38,7 @@ class TestTSVReader:
     def test_iter(self):
         reader = TSVReader("tests/test_data/test.tsv")
         for psm in reader:
-            assert psm.peptidoform == "ACDEK/2"
+            assert psm.peptidoform == Peptidoform("ACDEK/2")
             assert psm.spectrum_id == "peptide1"
             assert psm.provenance_data == {}
             assert psm.metadata == {}


### PR DESCRIPTION
### Fixed

- TSV: Avoid flooding logs when reading a different file format by raising exception when three consecutive rows could not be parsed