### PR TITLE
Implement eq and getitem dunder methods for Peptidoform

### DIFF
--- a/psm_utils/peptidoform.py
+++ b/psm_utils/peptidoform.py
@@ -66,17 +66,22 @@ class Peptidoform:
     def __hash__(self) -> int:
         return hash(self.proforma)
 
-    def __eq__(self, __o: Peptidoform) -> bool:
-        try:
+    def __eq__(self, __o: Union[Peptidoform, str]) -> bool:
+        if isinstance(__o, str):
+            return self.proforma == __o
+        elif isinstance(__o, Peptidoform):
             return self.proforma == __o.proforma
-        except AttributeError:
-            raise NotImplementedError("Object is not a Peptidoform")
+        else:
+            raise TypeError(f"Cannot compare {type(__o)} with Peptidoform.")
 
     def __iter__(self) -> Iterable[Tuple[str, Union[None, List[proforma.TagBase]]]]:
         return self.parsed_sequence.__iter__()
 
     def __len__(self) -> int:
         return self.parsed_sequence.__len__()
+
+    def __getitem__(self, key: int) -> Tuple[str, Union[None, List[proforma.TagBase]]]:
+        return self.parsed_sequence.__getitem__(key)
 
     @property
     def proforma(self) -> str:

--- a/tests/test_peptidoform.py
+++ b/tests/test_peptidoform.py
@@ -1,3 +1,4 @@
+import pytest
 from pyteomics import proforma
 
 from psm_utils.peptidoform import Peptidoform, format_number_as_string
@@ -33,6 +34,9 @@ class TestPeptidoform:
         for test_case_in_1, test_case_in_2, expected_out in test_cases:
             assert (Peptidoform(test_case_in_1) == test_case_in_2) == expected_out
             assert (Peptidoform(test_case_in_1) == Peptidoform(test_case_in_2)) == expected_out
+
+    with pytest.raises(TypeError):
+        Peptidoform("ACDEFGHIK") == 1
 
     def test__getitem__(self):
         test_cases = [

--- a/tests/test_peptidoform.py
+++ b/tests/test_peptidoform.py
@@ -18,6 +18,35 @@ class TestPeptidoform:
             peptidoform = Peptidoform(test_case_in)
             assert len(peptidoform) == expected_out
 
+    def test__eq__(self):
+        test_cases = [
+            ("ACDEFGHIK", "ACDEFGHIK", True),
+            ("ACDEFGHIK", "ACDEFGHI", False),
+            ("ACDEFGHIK/2", "ACDEFGHIK/2", True),
+            ("ACDEFGHIK/2", "ACDEFGHIK/3", False),
+            ("[ac]-AC[cm]DEFGHIK", "[ac]-AC[cm]DEFGHIK", True),
+            ("[ac]-AC[cm]DEFGHIK", "[ac]-AC[cm]DEFGH", False),
+            ("[ac]-AC[cm]DEFGHIK", "[ac]-AC[cm]DEFGH", False),
+            ("[ac]-AC[cm]DEFGHIK", "[ac]-AC[cm]DEFGH", False),
+        ]
+
+        for test_case_in_1, test_case_in_2, expected_out in test_cases:
+            assert (Peptidoform(test_case_in_1) == test_case_in_2) == expected_out
+            assert (Peptidoform(test_case_in_1) == Peptidoform(test_case_in_2)) == expected_out
+
+    def test__getitem__(self):
+        test_cases = [
+            ("ACDEFGHIK", 0, ("A", None)),
+            ("ACDEFGHIK", 8, ("K", None)),
+            ("[ac]-AC[cm]DEFGHIK", 0, ("A", None)),
+            ("[ac]-AC[cm]DEFGHIK", 1, ("C", [proforma.GenericModification("cm")])),
+            ("[ac]-AC[cm]DEFGHIK", 8, ("K", None)),
+        ]
+
+        for test_case_in, index, expected_out in test_cases:
+            peptidoform = Peptidoform(test_case_in)
+            assert peptidoform[index] == expected_out
+
     def test__iter__(self):
         for aa, mods in Peptidoform("ACDEM[U:35]K"):
             assert isinstance(aa, str)


### PR DESCRIPTION
### Added

- Peptidoform: Allow comparison between a peptidoform and a peptidoform string
- Peptidoform: Allow direct indexing with square brackets, which indexes or slices `parsed_sequence`