### PR TITLE
Percolator fixes: ScanNr writing and inferring style from file extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2024-08-28
+
+### Fixed
+
+- `io.percolator`: Fix and improve ScanNr inferring and writing
+- `io.percolator`: Infer style from file extension if not provided (enables dynamic style determination in, for instance, `convert` function).
+
 ## [1.0.0] - 2024-08-14
 
 ### Added

--- a/psm_utils/__init__.py
+++ b/psm_utils/__init__.py
@@ -1,6 +1,6 @@
 """Common utilities for parsing and handling PSMs, and search engine results."""
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __all__ = ["Peptidoform", "PSM", "PSMList"]
 
 from warnings import filterwarnings

--- a/tests/test_io/test_percolator.py
+++ b/tests/test_io/test_percolator.py
@@ -1,6 +1,10 @@
 """Tests for psm_utils.io.percolator."""
 
-from psm_utils.io.percolator import PercolatorTabReader
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from psm_utils.io.percolator import PercolatorIOException, PercolatorTabReader, PercolatorTabWriter
 
 
 class TestPercolatorTabReader:
@@ -32,3 +36,91 @@ class TestPercolatorTabReader:
         ]
         for test_in, expected_out in test_cases:
             assert expected_out == PercolatorTabReader._parse_peptidoform(*test_in).proforma
+
+
+@pytest.fixture
+def valid_pout_file():
+    return (
+        "PSMId\tLabel\tscore\tq-value\tposterior_error_prob\tpeptide\tproteinIds\n"
+        "PSM1\t1\t0.8\t0.01\t0.001\tPEPTIDE\tPROT1\n"
+        "PSM2\t-1\t0.7\t0.02\t0.002\tPEPTIDER\tPROT2\n"
+    )
+
+
+@pytest.fixture
+def invalid_pout_file():
+    return "Not a valid header\nSome invalid content"
+
+
+@pytest.fixture
+def empty_file():
+    return ""
+
+
+def test_parse_existing_file_valid(valid_pout_file):
+    with patch("builtins.open", mock_open(read_data=valid_pout_file)):
+        fieldnames, last_scannr = PercolatorTabWriter._parse_existing_file("dummy_path", "pout")
+        assert fieldnames == [
+            "PSMId",
+            "Label",
+            "score",
+            "q-value",
+            "posterior_error_prob",
+            "peptide",
+            "proteinIds",
+        ]
+        assert last_scannr == -1  # No ScanNr in POUT style, so it should be -1 by default
+
+
+def test_parse_existing_file_invalid(invalid_pout_file):
+    with patch("builtins.open", mock_open(read_data=invalid_pout_file)):
+        with pytest.raises(PercolatorIOException):
+            PercolatorTabWriter._parse_existing_file("dummy_path", "pin")
+
+
+def test_parse_existing_file_empty(empty_file):
+    with patch("builtins.open", mock_open(read_data=empty_file)):
+        with pytest.raises(PercolatorIOException):
+            PercolatorTabWriter._parse_existing_file("dummy_path", "pin")
+
+
+def test_parse_existing_file_no_scannr_column():
+    # Simulate a file without ScanNr column but a valid header and entries
+    data = (
+        "PSMId\tLabel\tscore\tq-value\tposterior_error_prob\tpeptide\tproteinIds\n"
+        "PSM1\t1\t0.8\t0.01\t0.001\tPEPTIDE\tPROT1\n"
+    )
+    with patch("builtins.open", mock_open(read_data=data)):
+        fieldnames, last_scannr = PercolatorTabWriter._parse_existing_file("dummy_path", "pout")
+        assert fieldnames == [
+            "PSMId",
+            "Label",
+            "score",
+            "q-value",
+            "posterior_error_prob",
+            "peptide",
+            "proteinIds",
+        ]
+        assert last_scannr == -1  # Since no ScanNr column exists, should default to -1
+
+
+def test_parse_existing_file_with_scannr():
+    # Simulate a file with ScanNr column and entries
+    data = (
+        "PSMId\tLabel\tScanNr\tscore\tq-value\tposterior_error_prob\tpeptide\tproteinIds\n"
+        "PSM1\t1\t0\t0.8\t0.01\t0.001\tPEPTIDE\tPROT1\n"
+        "PSM2\t1\t1\t0.7\t0.02\t0.002\tPEPTIDER\tPROT2\n"
+    )
+    with patch("builtins.open", mock_open(read_data=data)):
+        fieldnames, last_scannr = PercolatorTabWriter._parse_existing_file("dummy_path", "pout")
+        assert fieldnames == [
+            "PSMId",
+            "Label",
+            "ScanNr",
+            "score",
+            "q-value",
+            "posterior_error_prob",
+            "peptide",
+            "proteinIds",
+        ]
+        assert last_scannr == 1  # The last ScanNr should be 1


### PR DESCRIPTION
### Fixed

- `io.percolator`: Fix and improve ScanNr inferring and writing
- `io.percolator`: Infer style from file extension if not provided (enables dynamic style determination in, for instance, `convert` function).