### PR TITLE
Peptidoform: Add modified_sequence property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- `Peptidoform`: Add `modified_sequence` property to return the modified sequence in ProForma format, but without charge state.
+
+
 ## [1.0.1] - 2024-08-28
 
 ### Fixed

--- a/psm_utils/peptidoform.py
+++ b/psm_utils/peptidoform.py
@@ -110,6 +110,23 @@ class Peptidoform:
         return "".join(pos[0] for pos in self.parsed_sequence)
 
     @property
+    def modified_sequence(self) -> str:
+        """
+        Peptide sequence with modifications in ProForma format, but without charge state.
+
+        Includes all modifications, including labile, unlocalized, and terminal modifications.
+
+        Examples
+        --------
+        >>> Peptidoform("AC[U:4]DEK/2").modified_sequence
+        'AC[U:4]DEK'
+
+        """
+        properties_without_charge = self.properties.copy()
+        properties_without_charge.pop("charge_state", None)
+        return proforma.to_proforma(self.parsed_sequence, **properties_without_charge)
+
+    @property
     def precursor_charge(self) -> int | None:
         """
         Returns the charge state as integer or :py:const:`None` if no charge assigned.

--- a/tests/test_peptidoform.py
+++ b/tests/test_peptidoform.py
@@ -59,6 +59,44 @@ class TestPeptidoform:
                 for mod in mods:
                     assert isinstance(mod, proforma.TagBase)
 
+    def test_sequence(self):
+        test_cases = [
+            ("ACDEFGHIK", "ACDEFGHIK"),
+            ("[ac]-AC[cm]DEFGHIK", "ACDEFGHIK"),
+            ("[ac]-AC[Carbamidomethyl]DEFGHIK", "ACDEFGHIK"),
+            ("[Acetyl]-AC[cm]DEFGK", "ACDEFGK"),
+            ("<[cm]@C>[Acetyl]-ACDK", "ACDK"),
+            ("<[Carbamidomethyl]@C>[ac]-ACDEFGHIK", "ACDEFGHIK"),
+        ]
+
+        for test_case_in, expected_out in test_cases:
+            peptidoform = Peptidoform(test_case_in)
+            assert peptidoform.sequence == expected_out
+
+    def test_modified_sequence(self):
+        test_cases = [
+            ("ACDEFGHIK", "ACDEFGHIK"),
+            ("ACDEFGHIK/3", "ACDEFGHIK"),
+            ("[ac]-AC[cm]DEFGHIK", "[ac]-AC[cm]DEFGHIK"),
+            ("[ac]-AC[cm]DEFGHIK/3", "[ac]-AC[cm]DEFGHIK"),
+            ("<[cm]@C>[Acetyl]-ACDK/3", "<[cm]@C>[Acetyl]-ACDK"),
+        ]
+
+        for test_case_in, expected_out in test_cases:
+            peptidoform = Peptidoform(test_case_in)
+            assert peptidoform.modified_sequence == expected_out
+
+    def test_precursor_charge(self):
+        test_cases = [
+            ("ACDEFGHIK", None),
+            ("ACDEFGHIK/2", 2),
+            ("ACDEFGHIK/3", 3),
+        ]
+
+        for test_case_in, expected_out in test_cases:
+            peptidoform = Peptidoform(test_case_in)
+            assert peptidoform.precursor_charge == expected_out
+
     def test_rename_modifications(self):
         label_mapping = {
             "ac": "Acetyl",


### PR DESCRIPTION
### Added

- `Peptidoform`: Add `modified_sequence` property to return the modified sequence in ProForma format, but without charge state.

