### PR TITLE
Various IO fixes

### DIFF
--- a/psm_utils/io/__init__.py
+++ b/psm_utils/io/__init__.py
@@ -105,13 +105,13 @@ FILETYPES = {
         "reader": sage.SageTSVReader,
         "writer": None,
         "extension": ".tsv",
-        "filename_pattern": r"^.*(?:_|\.).sage.tsv$",
+        "filename_pattern": r"^.*(?:_|\.)sage.tsv$",
     },
     "sage_parquet": {
         "reader": sage.SageParquetReader,
         "writer": None,
         "extension": ".parquet",
-        "filename_pattern": r"^.*(?:_|\.).sage.parquet$",
+        "filename_pattern": r"^.*(?:_|\.)sage.parquet$",
     },
     "parquet": {  # List after proteoscape and sage to avoid extension matching conflicts
         "reader": parquet.ParquetReader,

--- a/psm_utils/io/flashlfq.py
+++ b/psm_utils/io/flashlfq.py
@@ -224,5 +224,5 @@ class FlashLFQWriter(WriterBase):
             "Peptide Monoisotopic Mass": f"{psm.peptidoform.theoretical_mass:.6f}",
             "Scan Retention Time": psm.retention_time,
             "Precursor Charge": psm.peptidoform.precursor_charge,
-            "Protein Accession": ";".join(psm.protein_list),
+            "Protein Accession": ";".join(psm.protein_list) if psm.protein_list else None,
         }


### PR DESCRIPTION
### Fixed

- `io`: Fix Sage filename pattern for automatic file type inference
- `io.flashlfq`: Fix writing PSMs without protein accession

