### PR TITLE
Recognize .pep.xml files

### DIFF
--- a/psm_utils/io/__init__.py
+++ b/psm_utils/io/__init__.py
@@ -69,7 +69,7 @@ FILETYPES = {
         "reader": pepxml.PepXMLReader,
         "writer": None,
         "extension": ".pepxml",
-        "filename_pattern": r"^.*\.pepxml$",
+        "filename_pattern": r"^.*\.pep\.?xml$",
     },
     "percolator": {
         "reader": percolator.PercolatorTabReader,

--- a/tests/test_io/test___init__.py
+++ b/tests/test_io/test___init__.py
@@ -18,6 +18,9 @@ def test__infer_filetype():
         ("name.t.xml", "xtandem"),
         ("name.msamanda.csv", "msamanda"),
         ("name_msamanda.csv", "msamanda"),
+        ("name.pepxml", "pepxml"),
+        ("name.pepXML", "pepxml"),
+        ("name.pep.xml", "pepxml"),
     ]
     for test_in, expected_out in test_cases:
         assert _infer_filetype(test_in) == expected_out


### PR DESCRIPTION
This is a simple regex change that allows `_infer_filetype` to recognize `.pep.xml` files as well as `.pepxml`.