### PR TITLE
PSMList: Use np.fromiter when using a string as accessor (e.g. `psm_list["peptidoform"]`)

### DIFF
--- a/psm_utils/psm_list.py
+++ b/psm_utils/psm_list.py
@@ -97,13 +97,7 @@ class PSMList(BaseModel):
             # Return new PSMList from slice
             return PSMList(psm_list=self.psm_list[item])
         elif isinstance(item, str):
-            # Return PSM property as array across full PSMList
-            try:
-                # Let NumPy coerce dtype (e.g., multidimensional arrays)
-                return np.array([psm[item] for psm in self.psm_list])
-            except ValueError:
-                # If dtype is not consistent, force dtype to be object
-                return np.array([psm[item] for psm in self.psm_list], dtype=object)
+            return np.fromiter([psm[item] for psm in self.psm_list], dtype=object, count=len(self))
         elif _is_iterable_of_bools(item):
             # Return new PSMList with items that were True
             return PSMList(psm_list=[self.psm_list[i] for i in np.flatnonzero(item)])

--- a/psm_utils/psm_list.py
+++ b/psm_utils/psm_list.py
@@ -97,6 +97,7 @@ class PSMList(BaseModel):
             # Return new PSMList from slice
             return PSMList(psm_list=self.psm_list[item])
         elif isinstance(item, str):
+            # Return PSM property as array across full PSMList
             return np.fromiter([psm[item] for psm in self.psm_list], dtype=object, count=len(self))
         elif _is_iterable_of_bools(item):
             # Return new PSMList with items that were True

--- a/tests/test_psm_list.py
+++ b/tests/test_psm_list.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from psm_utils import Peptidoform, PSM, PSMList
+from psm_utils import PSM, Peptidoform, PSMList
 
 sample_psm_list = [
     PSM(peptidoform="ACDK", spectrum_id=1, score=140.2),
@@ -42,7 +42,7 @@ class TestPSMList:
         # Multiple PSM properties as 2D array
         np.testing.assert_equal(
             psm_list[["spectrum_id", "score"]],
-            np.array([["1", 140.2], ["2", 132.9], ["3", 55.7]]),
+            np.array([["1", 140.2], ["2", 132.9], ["3", 55.7]], dtype=object),
         )
 
         # Index by multiple indices


### PR DESCRIPTION
### Changed

- When returning a PSM property across the full PSMList (e.g. `psm_list["peptidoform"]`), `np.fromiter` is now used instead of `np.array`. This fixes an issue where if all peptidoforms have the same length, a 3D array of parsed sequences (amino acids and modifications) was be returned instead of an array of `Peptidoform` object. However, this does mean that all resulting arrays will have the `object` dtype instead of the previously coerced dtypes. This might lead to issues downstream.
