### PR TITLE
Fix dtypes in numpy arrays from PSMList accession

### DIFF
--- a/psm_utils/psm.py
+++ b/psm_utils/psm.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import ConfigDict, BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from psm_utils.peptidoform import Peptidoform
 
@@ -135,3 +135,25 @@ class PSM(BaseModel):
         if as_url:
             usi = "http://proteomecentral.proteomexchange.org/usi/?usi=" + usi
         return usi
+
+
+NUMPY_DTYPES = {
+    "peptidoform": Peptidoform,
+    "spectrum_id": object,
+    "run": object,
+    "collection": object,
+    "spectrum": object,
+    "is_decoy": bool,
+    "score": float,
+    "qvalue": float,
+    "pep": float,
+    "precursor_mz": float,
+    "retention_time": float,
+    "ion_mobility": float,
+    "protein_list": object,
+    "rank": int,
+    "source": object,
+    "provenance_data": object,
+    "metadata": object,
+    "rescoring_features": object,
+}

--- a/psm_utils/psm_list.py
+++ b/psm_utils/psm_list.py
@@ -100,11 +100,11 @@ class PSMList(BaseModel):
             # Return PSM property as array across full PSMList
             try:
                 return np.fromiter(
-                    [psm[item] for psm in self.psm_list], dtype=NUMPY_DTYPES[item], count=len(self)
+                    (psm[item] for psm in self.psm_list), dtype=NUMPY_DTYPES[item], count=len(self)
                 )
             except TypeError:
                 return np.fromiter(
-                    [psm[item] for psm in self.psm_list], dtype=object, count=len(self)
+                    (psm[item] for psm in self.psm_list), dtype=object, count=len(self)
                 )
         elif _is_iterable_of_bools(item):
             # Return new PSMList with items that were True

--- a/psm_utils/psm_list.py
+++ b/psm_utils/psm_list.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 from pyteomics import auxiliary, proforma
 from rich.pretty import pretty_repr
 
-from psm_utils.psm import PSM
+from psm_utils.psm import NUMPY_DTYPES, PSM
 
 
 class PSMList(BaseModel):
@@ -98,7 +98,14 @@ class PSMList(BaseModel):
             return PSMList(psm_list=self.psm_list[item])
         elif isinstance(item, str):
             # Return PSM property as array across full PSMList
-            return np.fromiter([psm[item] for psm in self.psm_list], dtype=object, count=len(self))
+            try:
+                return np.fromiter(
+                    [psm[item] for psm in self.psm_list], dtype=NUMPY_DTYPES[item], count=len(self)
+                )
+            except TypeError:
+                return np.fromiter(
+                    [psm[item] for psm in self.psm_list], dtype=object, count=len(self)
+                )
         elif _is_iterable_of_bools(item):
             # Return new PSMList with items that were True
             return PSMList(psm_list=[self.psm_list[i] for i in np.flatnonzero(item)])

--- a/tests/test_psm_list.py
+++ b/tests/test_psm_list.py
@@ -38,6 +38,9 @@ class TestPSMList:
 
         # PSM property as array
         np.testing.assert_equal(psm_list["spectrum_id"], np.array(["1", "2", "3"]))
+        np.testing.assert_equal(psm_list["score"], np.array([140.2, 132.9, 55.7]))
+        np.testing.assert_equal(psm_list["rank"], np.array([None, None, None]))
+        np.testing.assert_equal(psm_list["qvalue"], np.array([np.nan, np.nan, np.nan]))
 
         # Multiple PSM properties as 2D array
         np.testing.assert_equal(


### PR DESCRIPTION
### Fixed

- Fix bug introduced in #102 where dtypes were not coerced anymore by Numpy, which lead to unexpected behavior downstream (e.g., `psm_list["is_decoy"]` would return an array of objects instead of bools)