### PR TITLE
Fix potential downstream issues because pepxml-read PSM had `rescoring_features=None`

### DIFF
--- a/psm_utils/io/pepxml.py
+++ b/psm_utils/io/pepxml.py
@@ -153,5 +153,5 @@ class PepXMLReader(ReaderBase):
                     for key in search_hit["search_score"]
                 }
             ),
-            rescoring_features=None,
+            rescoring_features=dict(),
         )


### PR DESCRIPTION
### Fixed

- Fix potential downstream issues because pepxml-read PSM had `rescoring_features=None` (partially fixes #108)