### PR TITLE
Explicitly set sphinx config path for readthedocs (fixes #115)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,3 +15,4 @@ python:
 
 sphinx:
   builder: dirhtml
+  configuration: docs/source/conf.py


### PR DESCRIPTION
### Fixed

- Docs: Explicitly set sphinx config path for readthedocs (fixes #115)