### PR TITLE
Fix: restore compatibility with older Sage versions with no ion_mobility column present

### DIFF
--- a/psm_utils/io/sage.py
+++ b/psm_utils/io/sage.py
@@ -108,7 +108,7 @@ class _SageReaderBase(ReaderBase, ABC):
         Parse ion mobility from PSM dictionary.
         Returns None if not present.
         """
-        if "ion_mobility" in psm_dict: # Older versions of Sage, no ion mobility column
+        if "ion_mobility" in psm_dict: # Older versions of Sage have no ion mobility column
             if float(psm_dict["ion_mobility"]): # If ion mobility is not 0.0 (not present)
                 return float(psm_dict["ion_mobility"])
         return None

--- a/psm_utils/io/sage.py
+++ b/psm_utils/io/sage.py
@@ -78,7 +78,7 @@ class _SageReaderBase(ReaderBase, ABC):
             score=float(psm_dict[self.score_column]),
             precursor_mz=self._parse_precursor_mz(psm_dict["expmass"], psm_dict["charge"]),
             retention_time=float(psm_dict["rt"]),
-            ion_mobility=float(psm_dict["ion_mobility"]) if float(psm_dict["ion_mobility"]) else None,
+            ion_mobility=self._parse_ion_mobility(psm_dict),
             protein_list=psm_dict["proteins"].split(";"),
             source="sage",
             rank=int(float(psm_dict["rank"])),
@@ -101,6 +101,17 @@ class _SageReaderBase(ReaderBase, ABC):
             return (expmass + (mass.nist_mass["H"][1][0] * charge)) / charge
         else:
             return None
+        
+    @staticmethod
+    def _parse_ion_mobility(psm_dict: dict) -> Optional[float]:
+        """
+        Parse ion mobility from PSM dictionary.
+        Returns None if not present.
+        """
+        if "ion_mobility" in psm_dict: # Older versions of Sage, no ion mobility column
+            if float(psm_dict["ion_mobility"]): # If ion mobility is not 0.0 (not present)
+                return float(psm_dict["ion_mobility"])
+        return None
 
     @classmethod
     def from_dataframe(cls, dataframe) -> PSMList:

--- a/psm_utils/io/sage.py
+++ b/psm_utils/io/sage.py
@@ -59,12 +59,13 @@ class _SageReaderBase(ReaderBase, ABC):
                 continue
         
         # If ion mobility is not 0.0 (not present), add it to the rescoring features     
-        if float(psm_dict['ion_mobility']):
-            rescoring_features.update({
-            'ion_mobility': float(psm_dict['ion_mobility']),
-            'predicted_mobility': float(psm_dict['predicted_mobility']),
-            'delta_mobility': float(psm_dict['delta_mobility'])
-            })
+        if "ion_mobility" in psm_dict: # Older versions of Sage have no ion mobility column
+            if float(psm_dict['ion_mobility']):
+                rescoring_features.update({
+                'ion_mobility': float(psm_dict['ion_mobility']),
+                'predicted_mobility': float(psm_dict['predicted_mobility']),
+                'delta_mobility': float(psm_dict['delta_mobility'])
+                })
 
         return PSM(
             peptidoform=self._parse_peptidoform(


### PR DESCRIPTION
### Fixed

- Restored compatibility with older Sage versions that have no ion mobility columns (introduced in v1.4.0)
