### PR TITLE
Show unknown modifications as delta mass in peptidoform

### DIFF
--- a/psm_utils/io/mzid.py
+++ b/psm_utils/io/mzid.py
@@ -20,7 +20,7 @@ from rich.progress import Progress
 
 from psm_utils import __version__
 from psm_utils.io._base_classes import ReaderBase, WriterBase
-from psm_utils.io.exceptions import PSMUtilsIOException
+from psm_utils.io.exceptions import PSMUtilsIOException, ModificationException
 from psm_utils.peptidoform import Peptidoform
 from psm_utils.psm import PSM
 from psm_utils.psm_list import PSMList
@@ -189,7 +189,15 @@ class MzidReader(ReaderBase):
 
         # Add modification labels
         for mod in modification_list:
-            peptide[int(mod["location"])] += f"[{mod['name']}]"
+            name = mod.get("name")
+            if name and name != "unknown modification":
+                tag = f"[{mod['name']}]"
+            elif "monoisotopicMassDelta" in mod:
+                s = mod["monoisotopicMassDelta"]
+                tag = f"[{s:+.5f}]"
+            else:
+                raise ModificationException(f"Not enough information about modification: {mod}")
+            peptide[int(mod["location"])] += tag
 
         # Add dashes between residues and termini, and join sequence
         peptide[0] = peptide[0] + "-" if peptide[0] else ""


### PR DESCRIPTION
This fixes a problem with MzIdentML files where some modifications are reported as `MS:1001460`, "unknown modification". Currently this results in peptidoforms such as `PEPTID[unknown modification]E`, where the modification can not be resolved and its mass information is lost.

With the fix, "unknown modification" is handled separately, producing instead a peptidoform with a delta-mass-designated modification, which allows mass calculations.

An example of a search engine producing affected mzid files is Comet 2025.02.0.