### PR TITLE
`io.pepxml`: Fix inferring score when first `spectrum_query` item does not have `search_hit` items.

### DIFF
--- a/online/pages/1_PSM_file_statistics.py
+++ b/online/pages/1_PSM_file_statistics.py
@@ -91,16 +91,18 @@ class StreamlitPageStats(StreamlitPage):
                 self.state["reverse"] = row[0].radio(
                     "Score type: order",
                     options=[True, False],
-                    format_func=lambda x: "Higher score is better"
-                    if x
-                    else "Lower score is better",
+                    format_func=lambda x: (
+                        "Higher score is better" if x else "Lower score is better"
+                    ),
                 )
                 self.state["log_scale"] = row[1].radio(
                     "Score type: scale",
                     options=[False, True],
-                    format_func=lambda x: "Logarithmic scale (e.g., e-value)"
-                    if x
-                    else "Linear scale (e.g., Andromeda score)",
+                    format_func=lambda x: (
+                        "Logarithmic scale (e.g., e-value)"
+                        if x
+                        else "Linear scale (e.g., Andromeda score)"
+                    ),
                     help=(
                         """
                         Some search engine scores, mostly e-value-like scores, require a

--- a/psm_utils/__init__.py
+++ b/psm_utils/__init__.py
@@ -1,6 +1,6 @@
 """Common utilities for parsing and handling PSMs, and search engine results."""
 
-__version__ = "1.5.1"
+__version__ = "1.5.2"
 __all__ = ["Peptidoform", "PSM", "PSMList"]
 
 from warnings import filterwarnings

--- a/psm_utils/io/pepxml.py
+++ b/psm_utils/io/pepxml.py
@@ -73,6 +73,8 @@ class PepXMLReader(ReaderBase):
         # Get scores from first PSM
         with pepxml.read(str(self.filename)) as reader:
             for spectrum_query in reader:
+                if "search_hit" not in spectrum_query:
+                    continue
                 score_keys = spectrum_query["search_hit"][0]["search_score"].keys()
                 break
             else:


### PR DESCRIPTION
### Fixed

- `io.pepxml`: Fix inferring score when first `spectrum_query` item does not have `search_hit` items (fixes #142)