### PR TITLE
Generalize whitespace handling in splitting modification column FragPipe

### DIFF
--- a/psm_utils/io/fragpipe.py
+++ b/psm_utils/io/fragpipe.py
@@ -119,7 +119,7 @@ class FragPipeReader(ReaderBase, ABC):
         if not modifications:
             return to_proforma(sequence, n_term=n_term, c_term=c_term, charge_state=charge)
 
-        for mod_entry in modifications.split(", "):
+        for mod_entry in (e.strip() for e in modifications.split(",")):
             if not mod_entry:
                 continue
 


### PR DESCRIPTION
Small improvement to the parsing logic for modifications in the `_parse_peptidoform` function in `psm_utils/io/fragpipe.py`. I am not sure of the reason why, but sometimes FragPipe output separates modification by ", " and sometimes just ",". Could have to do with versioning. This change ensures that any extra whitespace around modification entries is removed, making the parsing more robust to formatting inconsistencies.