### PR TITLE
fix parsing pepxml with none of the standard scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.5.5] - 2026-06-05
 
+### Fixed
+
+- `io.pepxml`: Fix a `TypeError` when none of the standard search engine scores are found and the fallback (`score_keys[0]`) is accessed (fixes #150)
+
 ### Changed
 
 - Pin version bounds for all core dependencies. Most notably, `pyteomics` is now constrained to `< 5` to avoid breaking changes introduced in the upcoming major release.

--- a/psm_utils/io/pepxml.py
+++ b/psm_utils/io/pepxml.py
@@ -75,7 +75,7 @@ class PepXMLReader(ReaderBase):
             for spectrum_query in reader:
                 if "search_hit" not in spectrum_query:
                     continue
-                score_keys = spectrum_query["search_hit"][0]["search_score"].keys()
+                score_keys = list(spectrum_query["search_hit"][0]["search_score"].keys())
                 break
             else:
                 score_keys = []


### PR DESCRIPTION
If nothing was found, we return the first element as fallback. However, dict_keys isn't subscriptable, resulting in issue compomics/ms2rescore#258 when none of the standard search engine scores were found. Making this a list fixes this.

However, if the order isn't significant (the order of the keys will be the order of insertion in current (C?)Python implementations, the order of the set would de-facto be according to the order of the hashes) we could also use a set here, and then use `score_keys.pop()` as fallback instead of `score_keys[0]`.